### PR TITLE
UI改进：化身候选/技能选择展示完整desc说明；左慈声明化身后座位卡头像切换为

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,6 +467,19 @@
   .seat-delays .dchip{font-size:8px;padding:0 3px;border:1px solid #7a5fa0;border-radius:4px;
     color:#e2d6f5;background:rgba(40,25,60,.75);white-space:nowrap;
     text-shadow:0 1px 2px rgba(0,0,0,.9);}
+  /* 左慈【化身】声明后的"化身：XX·YY"提示行:和 .seat-delays 的紫色系(锦囊)、
+     .seat-equip-bar 的金色系(装备)区分开,用青色系代表"借用的技能"这个新概念。
+     字号跟 .seat-equip-bar 同一套 clamp(cqw) 写法(按卡片自身宽度缩放,不需要额外的
+     @container 断点),自带不透明底衬(和 .dchip 同一原则,不依赖 .seat-scrim-bottom
+     的半透明渐变——那条渐变本身已经够用,这里多一层自己的底色只是让这一行在装备/判定区
+     之间更醒目、层次分明,不是必须)。整行可点击(cursor:pointer,呼应装备行/判定区chip
+     同样整行可点的既有交互),行内的"?"字符只是视觉提示,不是独立的可点击热区。 */
+  .seat-huashen-line{font-size:clamp(7px,6.5cqw,10px);padding:1px 4px;margin:0 3px 1px;
+    border:1px solid #3a8ba0;border-radius:4px;color:#bfe8f0;background:rgba(15,45,55,.75);
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer;
+    text-shadow:0 1px 2px rgba(0,0,0,.9);}
+  .seat-huashen-line .huashen-info-mark{font-weight:700;color:#8fd6e6;}
+  .seat.me .seat-huashen-line{font-size:10px;padding:2px 5px;}
   /* (第4次微调:原来这里有一条 .seat-title .info-badge 的尺寸规则,"?"已经从标题栏
      挪到右上角、身份方块下方,改由上面的 .seat-info-badge 负责尺寸和定位,这条已删除,
      不再保留一条永远命中不到的死规则。) */
@@ -592,6 +605,16 @@
     padding:10px 12px;margin:4px 0 0;font-size:14px;
   }
   .controls{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;flex-basis:100%;margin-top:2px;}
+  /* 左慈【化身】选技能环节(renderHuashenTwoStepPick):每个候选武将的按钮配一段完整
+     desc说明。.huashen-candidate 是"按钮+说明"的小容器,自己走 flex-direction:column
+     (按钮在上、说明在下),宽度限制在合理范围内避免整段desc撑成一长条——#controls本身
+     是flex-wrap的行,每个candidate容器是其中一个换行单元,和其它按钮混排也不冲突。
+     配色/字号复用三选一候选卡片(.general-pick-desc)已经验证过的暗淡小字风格,不新造
+     一套视觉语言。 */
+  .huashen-candidate{display:flex;flex-direction:column;align-items:stretch;gap:4px;
+    max-width:260px;}
+  .huashen-candidate-desc{font-size:12px;color:var(--paper-dim);line-height:1.5;
+    text-align:left;}
 
   /* 底部一整行:自己的座位卡(左)+手牌(右)——对应参考图"左下角自己座位卡+底部手牌行"。
      阶段1只做最基础的横排,skill按钮("豹头"样式的武将说明入口)等细节留给阶段3处理。 */
@@ -1172,16 +1195,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=141"></script>
-<script src="data.js?v=141"></script>
-<script src="room-lifecycle.js?v=141"></script>
-<script src="game.js?v=141"></script>
-<script src="weapons.js?v=141"></script>
-<script src="skills.js?v=141"></script>
-<script src="render.js?v=141"></script>
-<script src="render-table.js?v=141"></script>
-<script src="render-hand.js?v=141"></script>
-<script src="render-controls.js?v=141"></script>
-<script src="render-log.js?v=141"></script>
+<script src="config.js?v=142"></script>
+<script src="data.js?v=142"></script>
+<script src="room-lifecycle.js?v=142"></script>
+<script src="game.js?v=142"></script>
+<script src="weapons.js?v=142"></script>
+<script src="skills.js?v=142"></script>
+<script src="render.js?v=142"></script>
+<script src="render-table.js?v=142"></script>
+<script src="render-hand.js?v=142"></script>
+<script src="render-controls.js?v=142"></script>
+<script src="render-log.js?v=142"></script>
 </body>
 </html>

--- a/render-controls.js
+++ b/render-controls.js
@@ -206,12 +206,21 @@ function waitAskBanner(name, skill){
 function renderHuashenTwoStepPick(g, c, availGenerals, respondFn, titlePrefix){
   const pool = Array.isArray(availGenerals) ? availGenerals : [];
   if(huashenPickGeneral===null){
+    // 第一步(选武将):每个候选武将各是不同的武将,desc各不相同——每个候选按钮各自配
+    // 一段完整的GENERALS[gid].desc说明(不裁剪到单条技能),让玩家在选之前就能看清楚
+    // 整个武将的完整技能说明。按钮+说明包成一个小容器一起appendChild,保持"这段说明
+    // 属于哪个候选"视觉上一一对应,不和其它候选的按钮/说明混在一起。
     pool.forEach(gid=>{
       const gen=getGeneral(gid); if(!gen) return;
+      const wrap=document.createElement('div'); wrap.className='huashen-candidate';
       const b=document.createElement('button');
       b.textContent=gen.name+'('+gen.skill+')';
       b.onclick=()=>{ huashenPickGeneral=gid; render(g); };
-      c.appendChild(b);
+      wrap.appendChild(b);
+      const desc=document.createElement('div'); desc.className='huashen-candidate-desc';
+      desc.textContent=gen.desc||'(暂无说明)';
+      wrap.appendChild(desc);
+      c.appendChild(wrap);
     });
     setBanner('【'+titlePrefix+'】请选择要借用的武将…');
     return;
@@ -223,6 +232,15 @@ function renderHuashenTwoStepPick(g, c, availGenerals, respondFn, titlePrefix){
     respondFn(gid, skillName);
     return;
   }
+  // 第二步(选技能):这几个按钮全部属于同一个武将(huashenPickGeneral),desc是
+  // 同一份文本,不需要在每个技能按钮下都重复贴一遍——统一在按钮上方展示这一个武将的
+  // 完整desc一次,和第一步"每个候选各自一份"的处理方式不同,是因为第二步候选数量
+  // 少但内容重复,重复展示反而是视觉噪音。
+  const genForPick = getGeneral(huashenPickGeneral);
+  const descBlock=document.createElement('div'); descBlock.className='huashen-candidate-desc';
+  descBlock.style.cssText='flex-basis:100%;margin-bottom:4px;';
+  descBlock.textContent=(genForPick&&genForPick.desc)||'(暂无说明)';
+  c.appendChild(descBlock);
   entries.forEach(e=>{
     const b=document.createElement('button');
     b.textContent=e.name;
@@ -232,7 +250,7 @@ function renderHuashenTwoStepPick(g, c, availGenerals, respondFn, titlePrefix){
   const back=document.createElement('button'); back.className='ghost';
   back.textContent='重新选武将'; back.onclick=()=>{ huashenPickGeneral=null; render(g); };
   c.appendChild(back);
-  setBanner('【'+titlePrefix+'】请选择借用 '+(getGeneral(huashenPickGeneral)?getGeneral(huashenPickGeneral).name:'')+' 的哪个技能…');
+  setBanner('【'+titlePrefix+'】请选择借用 '+(genForPick?genForPick.name:'')+' 的哪个技能…');
 }
 // renderHuashenChangeAsk: 回合开始/结束"是否更改化身"的二选一询问,respondFn 是各自的
 // respondHuashenChangeAskStart/respondHuashenChangeAskEnd。

--- a/render.js
+++ b/render.js
@@ -404,8 +404,15 @@ function renderSeatCard(g, seat, isSelf){
   // 不够,三选一选将阶段选完但还没正式开局前仍是隐藏信息,这是一个真实修过的信息泄露bug
   // (见CLAUDE.md),这里延续同一条件不变。
   const avatarReady = g.started && gen;
+  // 左慈【化身】:声明借用某个武将后,座位卡头像改用那个武将的立绘,只改这一处视觉展示——
+  // p.general 本身恒为'zuoci',技能判定(hasCap/generalHasCap等)、genLabel、genNameVert
+  // 全部继续走 p.general/gen,不受这条影响。只在 p.general==='zuoci' 时才生效,不碰其他
+  // 任何武将的座位卡渲染(renderSeatCard 是所有座位共用的同一个函数)。avatarGen 拿不到
+  // (huashenGeneral 是脏数据/查无对应武将,理论上不该发生)时兜底退回 gen,不崩溃。
+  const isZuociWithHuashen = p.general==='zuoci' && p.huashenGeneral;
+  const avatarGen = isZuociWithHuashen ? (getGeneral(p.huashenGeneral) || gen) : gen;
   const avatarImg = avatarReady
-    ? '<img class="avatar" src="'+generalAvatarSrc(gen.id)+'" onerror="avatarError(this)" alt="">'
+    ? '<img class="avatar" src="'+generalAvatarSrc(avatarGen.id)+'" onerror="avatarError(this)" alt="">'
     : '';
   const avatarPlaceholder = '<div class="avatar-placeholder"'+(avatarReady?' style="display:none"':'')+'>'+escapeHtml(genLabel)+'</div>';
   // 武将名竖排(writing-mode:vertical-rl + text-orientation:upright,见CSS)。固定字号,
@@ -454,6 +461,21 @@ function renderSeatCard(g, seat, isSelf){
   // 渲染这一整行;手牌数在 g.started 时恒非空(至少是数字0,不会是空字符串),所以这行
   // 在开局后基本总会渲染,除非连手牌图标都判断为 null(未开局时)且也没有装备可显示。
   const equipRow = (handIcon || equipBar) ? '<div class="seat-equip-row">'+handIcon+equipBar+'</div>' : '';
+  // 左慈【化身】:声明借用某个武将后,座位卡新增一行"化身：<武将名>·<技能名>"+可点击
+  // "?"角标(复用 showGeneralInfo,和武将说明"?"同一套展示组件,不新造弹窗)。
+  // **放置位置的取舍**:字面上"名字下方"更贴近标题栏(.seat-title)正下方,但那一带
+  // (.seat-title/.seat-left 的像素级 top 偏移、竖排武将名高度、血量胶囊位置)是经过多轮
+  // WCAG对比度实测+响应式断点校准出来的脆弱几何(见CLAUDE.md第7次微调等多轮记录),往
+  // 那里插一条新行需要重新验证整套断点下的重叠/对比度,风险和工作量都明显偏高。改放进
+  // 已经证明能安全伸缩的 .seat-bottom(判定区+装备行所在的底部flex列,行数本来就是可变
+  // 的,判定区0~N行、装备区对手0~4行不等,早已验证过增删行不会打乱布局)。视觉上仿
+  // .seat-delays 的 .dchip(紫色系呼应锦囊)、装备行的金色高亮,这里用青色系区分"这是
+  // 借用的技能"这个新概念,不与既有色系混淆。
+  const huashenLine = (avatarReady && isZuociWithHuashen)
+    ? '<div class="seat-huashen-line" title="'+escapeHtml((avatarGen&&avatarGen.desc)||'')+'" onclick="event.stopPropagation();showGeneralInfo(\''+p.huashenGeneral+'\')">化身：'
+      + escapeHtml(avatarGen?avatarGen.name:p.huashenGeneral)+'·'+escapeHtml(p.huashenSkillName||'')
+      + ' <span class="huashen-info-mark">?</span></div>'
+    : '';
   // 判定区(延时锦囊):紫色 chip,叠在装备条上方(仍在图片上层),同样自带半透明底衬。
   const delayRow = (g.started && (p.delays||[]).length>0)
     ? '<div class="seat-delays">'+p.delays.map(c=>{
@@ -522,7 +544,7 @@ function renderSeatCard(g, seat, isSelf){
     // 确认"右上角只有身份牌"这个现状继续保留,不新增内容,这里未改动。**
     + '<div class="seat-identity"></div>'
     + infoBadge
-    + '<div class="seat-bottom">'+delayRow+equipRow+'</div>';
+    + '<div class="seat-bottom">'+huashenLine+delayRow+equipRow+'</div>';
 }
 
 


### PR DESCRIPTION
借用武将立绘、新增"化身：XX·YY"说明行(含?角标弹出完整desc)，放置于.seat-bottom (避开.seat-left已校准的脆弱几何)。仅影响左慈自身座位卡渲染，其他玩家/隐藏信息
窗口期不受影响。18项Playwright真实浏览器测试(含截图确认)+既有回归零破坏。
?v=141→142。