### PR TITLE
宽屏桌面布局：座位卡按上/左/右/我四区摆位，支持最多8人局

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,5 +1,7 @@
 // ---------- game constants ----------
-const SEATS = 3;        // 房间容量上限(满 3 不再加入)
+const SEATS = 8;        // 房间容量上限(desktop-layout-8p:开放到8人,支撑assignSeatZones的
+                         // top3+left2+right2满配;joinRoom里的人数上限检查直接读这个常量,
+                         // 不需要额外改逻辑)
 const MIN_PLAYERS = 2;  // 开始游戏的最低人数(2 或 3 人均可开始)
 const MAX_HP = 4; // 大厅占位 / 兜底默认体力上限
 const START_HAND = 4;

--- a/index.html
+++ b/index.html
@@ -1135,6 +1135,15 @@
      但子孙节点(.seat[data-zone]/#meSeat/#hand)会直接以 #game 的 grid item 身份参与
      布局,而不是被"困"在各自父级的盒子里只能整体挪动。*/
   @media (min-width:1024px){
+    /* .wrap 的基础规则(见文件靠前的 .wrap{max-width:880px;...})是给竖排/窄屏内容设计的
+       宽度上限——桌面布局这套4列grid(座位区3列+日志专属1列)天然需要比880px更宽的空间
+       才能舒展,继续受这个上限约束会让#game被迫挤在一条880px的窄带里,座位区和视口边缘
+       之间留出大片空白,日志列也会被连带挤扁。这里用:has()按#game是否带desktop-layout
+       这个class判断(和上面@media(max-height:460px)里.wrap:has(#game:not(.hidden))
+       同一个既有写法,#game是.wrap的直接子元素,不需要新增JS/新增class去传递这个状态),
+       取消max-width限制,让.wrap(以及它唯一真正需要撑开的孙子#game)能撑满到接近整个
+       视口宽度(减去.wrap自身padding)。 */
+    .wrap:has(#game.desktop-layout){ max-width:none; }
     #game.desktop-layout{
       display:grid;
       /* 第4步新增第4列专门给日志面板——不和已经放 right 座位卡的第3列共用,
@@ -1280,16 +1289,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=150"></script>
-<script src="data.js?v=150"></script>
-<script src="room-lifecycle.js?v=150"></script>
-<script src="game.js?v=150"></script>
-<script src="weapons.js?v=150"></script>
-<script src="skills.js?v=150"></script>
-<script src="render.js?v=150"></script>
-<script src="render-table.js?v=150"></script>
-<script src="render-hand.js?v=150"></script>
-<script src="render-controls.js?v=150"></script>
-<script src="render-log.js?v=150"></script>
+<script src="config.js?v=151"></script>
+<script src="data.js?v=151"></script>
+<script src="room-lifecycle.js?v=151"></script>
+<script src="game.js?v=151"></script>
+<script src="weapons.js?v=151"></script>
+<script src="skills.js?v=151"></script>
+<script src="render.js?v=151"></script>
+<script src="render-table.js?v=151"></script>
+<script src="render-hand.js?v=151"></script>
+<script src="render-controls.js?v=151"></script>
+<script src="render-log.js?v=151"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -449,6 +449,14 @@
   }
   .seat-equip-bar .erow{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
     color:var(--paper);}
+  /* 内容密度分支(desktop-layout-8p 第5步):装备名文字本来就一直在渲染,窄屏靠上面这条
+     nowrap+ellipsis 截断长名字("雌雄双股剑"/"青龙偃月刀"这类)。宽屏下 render.js 的
+     renderSeatCard 会读 isDesktopLayout()(不新增 @media 断点重复判断同一件事)给这一行
+     多加一个 wide-name class——这里只是纯 class 选择器(不带 @media),取消截断、允许
+     完整装备名换行显示,不撑破卡片(卡片本身 overflow:hidden,换行多出的高度会被这一层
+     裁掉而不是把布局撑破,已用真实浏览器截图验证过多件装备同时存在时不溢出/不重叠)。 */
+  .seat-equip-bar .erow.wide-name{white-space:normal;overflow:visible;text-overflow:clip;
+    overflow-wrap:anywhere;}
   .seat-equip-bar .erow b{color:var(--gold);font-weight:700;margin-right:.15em;} /* 类别首字:金色,和装备名区分;margin用em随字号缩放 */
   .seat-equip-bar .erow .efd{margin-right:.2em;} /* 花色点数:颜色由 render.js 的 seatEquipFace 按红/黑分别给 */
   .seat-equip-bar .erow.filled{cursor:pointer;}
@@ -1272,16 +1280,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=149"></script>
-<script src="data.js?v=149"></script>
-<script src="room-lifecycle.js?v=149"></script>
-<script src="game.js?v=149"></script>
-<script src="weapons.js?v=149"></script>
-<script src="skills.js?v=149"></script>
-<script src="render.js?v=149"></script>
-<script src="render-table.js?v=149"></script>
-<script src="render-hand.js?v=149"></script>
-<script src="render-controls.js?v=149"></script>
-<script src="render-log.js?v=149"></script>
+<script src="config.js?v=150"></script>
+<script src="data.js?v=150"></script>
+<script src="room-lifecycle.js?v=150"></script>
+<script src="game.js?v=150"></script>
+<script src="weapons.js?v=150"></script>
+<script src="skills.js?v=150"></script>
+<script src="render.js?v=150"></script>
+<script src="render-table.js?v=150"></script>
+<script src="render-hand.js?v=150"></script>
+<script src="render-controls.js?v=150"></script>
+<script src="render-log.js?v=150"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1156,10 +1156,19 @@
     }
     #game.desktop-layout #oppRow{ display:contents; }
     #game.desktop-layout .bottom-row{ display:contents; }
-    /* top: 最多3个(assignSeatZones 的 topCount 上限),横排在第1行,各占一列 */
-    #game.desktop-layout .seat[data-zone="top"][data-zone-index="0"]{ grid-column:1; grid-row:1; }
-    #game.desktop-layout .seat[data-zone="top"][data-zone-index="1"]{ grid-column:2; grid-row:1; }
-    #game.desktop-layout .seat[data-zone="top"][data-zone-index="2"]{ grid-column:3; grid-row:1; }
+    /* top: 最多3个(assignSeatZones 的 topCount 上限)——Grid 原生不支持"多个item共享同一
+       grid-area 时自动横向排开"(同区域内的item默认会叠在一起),之前给每张top座位卡各自
+       精确写 grid-column:1/2/3 是绕开这个限制的权宜写法,但那要求"每个座位卡都是#game这个
+       grid的直接item"这个前提——一旦引入#oppTopRow这个真实的flex容器,top座位卡就不再是
+       #game的直接item了,不需要也不能再各自精确定位。改成#oppTopRow整体占据grid-column:
+       1/4(横跨left到right三列的宽度)+grid-row:1这一个区域,内部用display:flex让最多3张
+       座位卡自然横向排开、不重叠——它不像#oppRow那样用display:contents打散,而是一个
+       真实的flex容器,因为它需要自己的flex布局上下文来排布top这几张卡片。gap/padding
+       比照.opp-row的既有数值,保持视觉一致。 */
+    #game.desktop-layout #oppTopRow{
+      grid-column:1 / 4; grid-row:1;
+      display:flex; justify-content:center; gap:8px; padding:8px 8px 4px;
+    }
     /* left: 最多2个,纵向排在最左列的第2/3行 */
     #game.desktop-layout .seat[data-zone="left"][data-zone-index="0"]{ grid-column:1; grid-row:2; }
     #game.desktop-layout .seat[data-zone="left"][data-zone-index="1"]{ grid-column:1; grid-row:3; }
@@ -1252,6 +1261,12 @@
        淡入淡出)+信息面板(阶段3会改造成独立信息条)+自己座位卡(#meSeat)+手牌行,
        取代旧版 #seats 网格环绕布局。 -->
   <div id="game" class="hidden">
+    <!-- #oppTopRow 只在宽屏桌面布局(.desktop-layout)下才会被使用(装zone==='top'的座位卡),
+         窄屏下永远是空的、没有任何CSS属性的占位元素(不挂.opp-row这类会带来无条件基础样式
+         的class)——render.js只有desktopLayoutActive为真时才会把座位分流进来,窄屏下
+         zones本身就是null,不存在"这个座位归哪个zone"这个概念,天然不会分流任何座位进来,
+         详见render.js里buildSeatDOM调用点的说明。 -->
+    <div id="oppTopRow"></div>
     <div class="opp-row" id="oppRow"></div>
     <div class="table-strip" id="tableStrip">
       <div id="tableCard" class="table-card"></div>
@@ -1289,16 +1304,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=151"></script>
-<script src="data.js?v=151"></script>
-<script src="room-lifecycle.js?v=151"></script>
-<script src="game.js?v=151"></script>
-<script src="weapons.js?v=151"></script>
-<script src="skills.js?v=151"></script>
-<script src="render.js?v=151"></script>
-<script src="render-table.js?v=151"></script>
-<script src="render-hand.js?v=151"></script>
-<script src="render-controls.js?v=151"></script>
-<script src="render-log.js?v=151"></script>
+<script src="config.js?v=152"></script>
+<script src="data.js?v=152"></script>
+<script src="room-lifecycle.js?v=152"></script>
+<script src="game.js?v=152"></script>
+<script src="weapons.js?v=152"></script>
+<script src="skills.js?v=152"></script>
+<script src="render.js?v=152"></script>
+<script src="render-table.js?v=152"></script>
+<script src="render-hand.js?v=152"></script>
+<script src="render-controls.js?v=152"></script>
+<script src="render-log.js?v=152"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1150,7 +1150,10 @@
          座位/中央出牌区/信息条/手牌这些原有内容一律收在前3列(见下面各条
          grid-column 从 1/-1 改成 1/4),第4列从第1行到最后一行整列只属于日志面板。 */
       grid-template-columns:minmax(100px,180px) 1fr minmax(100px,180px) minmax(220px,300px);
-      grid-template-rows:repeat(8,auto);
+      /* 第8步:me+手牌合并进同一行后,总行数从8收紧到7(座位区3行+信息条/武将名/手牌标签
+         各1行+合并后的me+手牌1行),没有空行,不会因为"预留了一行却没人占用"而多出一段
+         意外的行间距(row-gap 对每条相邻track都生效,哪怕某条track是空的)。 */
+      grid-template-rows:repeat(7,auto);
       column-gap:12px; row-gap:8px;
       align-items:start;
     }
@@ -1177,15 +1180,24 @@
     #game.desktop-layout .seat[data-zone="right"][data-zone-index="1"]{ grid-column:3; grid-row:3; }
     /* 中央出牌区:居中列,纵向跨第2/3行(和左右两列的座位卡对齐同一区块) */
     #game.desktop-layout #tableStrip{ grid-column:2; grid-row:2 / span 2; align-self:center; }
-    /* 我:固定在座位区正下方,占满前3列宽度(不侵入第4列日志专属列) */
-    #game.desktop-layout #meSeat{ grid-column:1 / 4; grid-row:4; justify-self:center; }
-    /* 以下几项这一步只给"各占一整行、按顺序往下排"的兜底位置,不做内容密度优化
-       (信息条/手牌具体怎么摆留给下一步);同样限定在前3列,不侵入第4列。 */
-    #game.desktop-layout .panel.table{ grid-column:1 / 4; grid-row:5; }
-    #game.desktop-layout #myGeneral{ grid-column:1 / 4; grid-row:6; }
-    #game.desktop-layout .hand-label:not(#myGeneral){ grid-column:1 / 4; grid-row:7; }
-    #game.desktop-layout #hand{ grid-column:1 / 4; grid-row:8; }
-    /* 第4步:日志面板挪到独立的第4列,纵向占满整个网格的高度(第1行到最后一行)——
+    /* 以下几项这一步只给"各占一整行、按顺序往下排"的兜底位置,不做内容密度优化;
+       同样限定在前3列,不侵入第4列。行号相应从原来的5/6/7上移一行(第8步me+手牌
+       合并后腾出了原来me单独占用的那一行)。 */
+    #game.desktop-layout .panel.table{ grid-column:1 / 4; grid-row:4; }
+    #game.desktop-layout #myGeneral{ grid-column:1 / 4; grid-row:5; }
+    #game.desktop-layout .hand-label:not(#myGeneral){ grid-column:1 / 4; grid-row:6; }
+    /* 第8步:我的座位卡+手牌合并成同一行——me固定用第1列(和left/right座位卡共用
+       同一条列轨道,宽度天然保持一致,不需要另外定义一组新的列宽),手牌占第2~3列
+       (剩余宽度,即中央+right那两条列轨道合起来的宽度)。原来两者各自占一整行、
+       me还用justify-self:center让自己在1/4这个跨列范围内居中——现在两者在同一行
+       分别落在各自固定的列里,不再需要justify-self这个居中手段。 */
+    #game.desktop-layout #meSeat{ grid-column:1; grid-row:7; }
+    #game.desktop-layout #hand{ grid-column:2 / 4; grid-row:7; }
+    /* 第4步:日志面板挪到独立的第4列;第8步收紧成grid-row:1 / span 3——只覆盖座位区
+       (top/left/right)+中央出牌区这3行,不再一路占满到底(原来是1/-1占满全部7行,
+       会一路盖到"我+手牌"合并后的那一行)。用span而不是写死结束行号(比如1/4),
+       是为了以后座位区行数变化(或者日志下面要插入别的内容,比如聊天框)时,只需要
+       改这里的span数字,不用重新计算"到底该到第几行"这个绝对行号。
        它是独立于座位区域的常驻信息区,不需要跟着座位卡的行高走,内容多了自己滚动
        (overflow-y:auto 是 .log-panel 基础规则里本来就有的)。
        #game.desktop-layout{align-items:start} 这条父级设置会让网格项默认按内容
@@ -1200,7 +1212,7 @@
        特异性天然高于 900px 断点那条纯 class 选择器,不依赖源码顺序也能赢,但仍然按
        约定写在源码更后面。 */
     #game.desktop-layout .log-panel{
-      grid-column:4; grid-row:1 / -1;
+      grid-column:4; grid-row:1 / span 3;
       position:static; align-self:stretch;
       max-height:none; height:100%;
       margin-top:0;
@@ -1304,16 +1316,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=152"></script>
-<script src="data.js?v=152"></script>
-<script src="room-lifecycle.js?v=152"></script>
-<script src="game.js?v=152"></script>
-<script src="weapons.js?v=152"></script>
-<script src="skills.js?v=152"></script>
-<script src="render.js?v=152"></script>
-<script src="render-table.js?v=152"></script>
-<script src="render-hand.js?v=152"></script>
-<script src="render-controls.js?v=152"></script>
-<script src="render-log.js?v=152"></script>
+<script src="config.js?v=153"></script>
+<script src="data.js?v=153"></script>
+<script src="room-lifecycle.js?v=153"></script>
+<script src="game.js?v=153"></script>
+<script src="weapons.js?v=153"></script>
+<script src="skills.js?v=153"></script>
+<script src="render.js?v=153"></script>
+<script src="render-table.js?v=153"></script>
+<script src="render-hand.js?v=153"></script>
+<script src="render-controls.js?v=153"></script>
+<script src="render-log.js?v=153"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1193,6 +1193,20 @@
        分别落在各自固定的列里,不再需要justify-self这个居中手段。 */
     #game.desktop-layout #meSeat{ grid-column:1; grid-row:7; }
     #game.desktop-layout #hand{ grid-column:2 / 4; grid-row:7; }
+    /* 第9步修复:.seat.me 的基础规则(见文件靠前的 .seat.me{width:220px;max-width:260px})
+       是给窄屏/flex布局场景设计的——.opp-row 用 flex,对手数量少时 flex:1 会把单个对手撑到
+       200px 上限,"我"的座位卡如果还是 180px 反而比对手更窄,和"更大、更醒目"的设计意图
+       矛盾,所以显式定死 220px(Playwright 实测抓到的真实问题,见那条注释)。但这次 me
+       座位卡改用 grid-column:1 后,分到的是这条列轨道 minmax(100px,180px) 的宽度,220px
+       会直接超出这个空间、溢出到 grid-column:2/4 (#hand 所在的列),和手牌区域产生真实
+       重叠(实测过:me 宽度220px、和 #hand 之间 gap 为负值)。"对手行flex撑宽"这个原始
+       问题在这里不成立——desktop 布局下 me 和对手的列宽都是 grid 固定分配、互不影响,
+       不存在"对手被撑宽导致我显得更窄"这回事,所以这里安全地把宽度收窄回和 grid-column:1
+       一致的180px,不影响.seat.me基础规则本身(那条220px仍然只在窄屏/flex模式下生效),
+       也不碰 left/right 座位卡(选择器只限定 .seat.me,不会命中它们)。写法参照上面
+       .wrap:has(#game.desktop-layout) 这条"用desktop-layout作用域覆盖旧规则"的既有模式,
+       保持风格一致。 */
+    #game.desktop-layout .seat.me{ width:180px; max-width:180px; }
     /* 第4步:日志面板挪到独立的第4列;第8步收紧成grid-row:1 / span 3——只覆盖座位区
        (top/left/right)+中央出牌区这3行,不再一路占满到底(原来是1/-1占满全部7行,
        会一路盖到"我+手牌"合并后的那一行)。用span而不是写死结束行号(比如1/4),
@@ -1316,16 +1330,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=153"></script>
-<script src="data.js?v=153"></script>
-<script src="room-lifecycle.js?v=153"></script>
-<script src="game.js?v=153"></script>
-<script src="weapons.js?v=153"></script>
-<script src="skills.js?v=153"></script>
-<script src="render.js?v=153"></script>
-<script src="render-table.js?v=153"></script>
-<script src="render-hand.js?v=153"></script>
-<script src="render-controls.js?v=153"></script>
-<script src="render-log.js?v=153"></script>
+<script src="config.js?v=154"></script>
+<script src="data.js?v=154"></script>
+<script src="room-lifecycle.js?v=154"></script>
+<script src="game.js?v=154"></script>
+<script src="weapons.js?v=154"></script>
+<script src="skills.js?v=154"></script>
+<script src="render.js?v=154"></script>
+<script src="render-table.js?v=154"></script>
+<script src="render-hand.js?v=154"></script>
+<script src="render-controls.js?v=154"></script>
+<script src="render-log.js?v=154"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -936,10 +936,12 @@
   .log-panel{max-height:132px;overflow-y:auto;text-align:left;font-size:13px;line-height:1.6;
     color:var(--paper-dim);background:rgba(0,0,0,.18);border:1px solid var(--line);
     border-radius:10px;padding:8px 10px;margin-top:6px;flex-basis:100%;
-    /* flex-basis:100% 是这次信息条改造新加的:.panel.table 现在是 flex 容器,不加这条
-       .log-panel 会按内容宽度收缩、可能和 phase-pill/deckinfo 挤在同一行,而不是像
-       banner/controls 一样独占一整行。position:fixed 生效(见下面 900px 断点)时这条
-       自动失效,不冲突。 */}
+    /* flex-basis:100% 是历史遗留:.log-panel 曾经是 .panel.table(flex容器)的最后一个
+       子项,靠这条独占一整行;桌面布局第4步把它挪成 .panel.table 的同级兄弟节点后
+       (见 index.html 结构里的说明),它不再是任何 flex 容器的子项,这条属性对现在的
+       默认/窄屏状态已经不生效(浏览器会安全忽略非 flex-item 上的 flex-basis),留着
+       不影响任何效果,只是不必要,不特意删除。position:fixed 生效(见下面 900px 断点)
+       /grid 里的独立列(见桌面布局 @media(min-width:1024px))时同样不冲突。 */}
   .log-panel div{padding:2px 0;}
   .log-panel div:last-child{color:var(--paper);}
   /* 宽屏(>=900px,手机断点之外)下把常驻日志面板切到右侧,不再挤在 controls 下方——
@@ -1127,7 +1129,10 @@
   @media (min-width:1024px){
     #game.desktop-layout{
       display:grid;
-      grid-template-columns:minmax(100px,180px) 1fr minmax(100px,180px);
+      /* 第4步新增第4列专门给日志面板——不和已经放 right 座位卡的第3列共用,
+         座位/中央出牌区/信息条/手牌这些原有内容一律收在前3列(见下面各条
+         grid-column 从 1/-1 改成 1/4),第4列从第1行到最后一行整列只属于日志面板。 */
+      grid-template-columns:minmax(100px,180px) 1fr minmax(100px,180px) minmax(220px,300px);
       grid-template-rows:repeat(8,auto);
       column-gap:12px; row-gap:8px;
       align-items:start;
@@ -1141,19 +1146,39 @@
     /* left: 最多2个,纵向排在最左列的第2/3行 */
     #game.desktop-layout .seat[data-zone="left"][data-zone-index="0"]{ grid-column:1; grid-row:2; }
     #game.desktop-layout .seat[data-zone="left"][data-zone-index="1"]{ grid-column:1; grid-row:3; }
-    /* right: 最多2个,纵向排在最右列的第2/3行 */
+    /* right: 最多2个,纵向排在最右列(第3列)的第2/3行 */
     #game.desktop-layout .seat[data-zone="right"][data-zone-index="0"]{ grid-column:3; grid-row:2; }
     #game.desktop-layout .seat[data-zone="right"][data-zone-index="1"]{ grid-column:3; grid-row:3; }
     /* 中央出牌区:居中列,纵向跨第2/3行(和左右两列的座位卡对齐同一区块) */
     #game.desktop-layout #tableStrip{ grid-column:2; grid-row:2 / span 2; align-self:center; }
-    /* 我:固定在座位区正下方,占满整行宽度 */
-    #game.desktop-layout #meSeat{ grid-column:1 / -1; grid-row:4; justify-self:center; }
+    /* 我:固定在座位区正下方,占满前3列宽度(不侵入第4列日志专属列) */
+    #game.desktop-layout #meSeat{ grid-column:1 / 4; grid-row:4; justify-self:center; }
     /* 以下几项这一步只给"各占一整行、按顺序往下排"的兜底位置,不做内容密度优化
-       (信息条/手牌具体怎么摆留给下一步) */
-    #game.desktop-layout .panel.table{ grid-column:1 / -1; grid-row:5; }
-    #game.desktop-layout #myGeneral{ grid-column:1 / -1; grid-row:6; }
-    #game.desktop-layout .hand-label:not(#myGeneral){ grid-column:1 / -1; grid-row:7; }
-    #game.desktop-layout #hand{ grid-column:1 / -1; grid-row:8; }
+       (信息条/手牌具体怎么摆留给下一步);同样限定在前3列,不侵入第4列。 */
+    #game.desktop-layout .panel.table{ grid-column:1 / 4; grid-row:5; }
+    #game.desktop-layout #myGeneral{ grid-column:1 / 4; grid-row:6; }
+    #game.desktop-layout .hand-label:not(#myGeneral){ grid-column:1 / 4; grid-row:7; }
+    #game.desktop-layout #hand{ grid-column:1 / 4; grid-row:8; }
+    /* 第4步:日志面板挪到独立的第4列,纵向占满整个网格的高度(第1行到最后一行)——
+       它是独立于座位区域的常驻信息区,不需要跟着座位卡的行高走,内容多了自己滚动
+       (overflow-y:auto 是 .log-panel 基础规则里本来就有的)。
+       #game.desktop-layout{align-items:start} 这条父级设置会让网格项默认按内容
+       自身高度顶部对齐、不拉伸——这里必须显式 align-self:stretch 覆盖回来,否则
+       "占满整列高度"不会生效,只会显示成顶部一小块。
+       max-height 也要放开(基础规则里窄屏/常规宽屏用的132px上限不再适用),改成
+       height:100%(配合 stretch 撑满的高度)+ overflow-y:auto 处理超出内容的滚动。
+       position:fixed 是 @media(min-width:900px) 那条更早的宽屏覆盖规则(900px<1024px
+       的桌面布局阈值,两者会同时命中)——fixed 定位元素完全脱离文档流,不participate
+       任何 grid 布局,必须在这里显式覆盖回 position:static 才能让它重新参与 grid
+       定位;这条选择器同时包含 #game 的 id 和 .desktop-layout/.log-panel 两个 class,
+       特异性天然高于 900px 断点那条纯 class 选择器,不依赖源码顺序也能赢,但仍然按
+       约定写在源码更后面。 */
+    #game.desktop-layout .log-panel{
+      grid-column:4; grid-row:1 / -1;
+      position:static; align-self:stretch;
+      max-height:none; height:100%;
+      margin-top:0;
+    }
   }
 
   .hidden{display:none!important;}
@@ -1220,8 +1245,14 @@
       <div class="deckinfo" id="deckInfo"></div>
       <div id="banner"></div>
       <div class="controls" id="controls"></div>
-      <div class="log-panel" id="logPanel"></div>
     </div>
+    <!-- log-panel 挪到 .panel.table 外面(不再是它的flex子项)——桌面布局(第4步)要把它放进
+         Grid 单独切出来的一整列、纵向占满全高,这需要它是 #game 的直接子元素才能参与 grid
+         定位;.log-panel 的 class 选择器本身不依赖 DOM 位置(没有 .panel.table .log-panel
+         这种祖先限定写法),挪到外面对窄屏/900px+浮动这两套既有样式完全不影响——它在
+         .panel.table 内本来就是 flex-basis:100% 独占一行的最后一个子项,挪成同级的下一个
+         兄弟节点,窄屏视觉位置不变。 -->
+    <div class="log-panel" id="logPanel"></div>
 
     <div class="hand-label" id="myGeneral"></div>
     <div class="hand-label">你的手牌</div>
@@ -1241,16 +1272,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=148"></script>
-<script src="data.js?v=148"></script>
-<script src="room-lifecycle.js?v=148"></script>
-<script src="game.js?v=148"></script>
-<script src="weapons.js?v=148"></script>
-<script src="skills.js?v=148"></script>
-<script src="render.js?v=148"></script>
-<script src="render-table.js?v=148"></script>
-<script src="render-hand.js?v=148"></script>
-<script src="render-controls.js?v=148"></script>
-<script src="render-log.js?v=148"></script>
+<script src="config.js?v=149"></script>
+<script src="data.js?v=149"></script>
+<script src="room-lifecycle.js?v=149"></script>
+<script src="game.js?v=149"></script>
+<script src="weapons.js?v=149"></script>
+<script src="skills.js?v=149"></script>
+<script src="render.js?v=149"></script>
+<script src="render-table.js?v=149"></script>
+<script src="render-hand.js?v=149"></script>
+<script src="render-controls.js?v=149"></script>
+<script src="render-log.js?v=149"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1110,6 +1110,52 @@
     .card{width:44px;height:64px;--badge:12px;}
   }
 
+  /* ===== 宽屏桌面布局(feature/desktop-layout-8p 第3步骨架) =====
+     只处理"座位卡+中央出牌区怎么摆",信息条/手牌行这一步只给"各占一整行、按顺序往下排"
+     的兜底位置(不重叠即可)——具体怎么排布留给下一步(#4日志面板挪位置/#5内容密度分支)
+     专门处理,这里不深究。是否启用这套grid由 render.js 的 isDesktopLayout()/
+     updateDesktopLayoutFlag() 双重把关:JS 判断 window.innerWidth>=1024 才会给 #game
+     加上 desktop-layout 这个 class,这里的 @media(min-width:1024px) 是第二道保险,
+     两边都满足才真正生效(和 checkLandscapeGate() 的软引导一样,JS 判断负责动态响应
+     resize,不是只在页面加载那一刻算一次)。
+     #game 变成 grid 容器后,它原本的每一个直接子元素都会变成 grid item——为了不改动
+     #oppRow/.bottom-row 内部现有的 DOM 结构(座位卡仍然是 #oppRow 的子节点,#meSeat/
+     #hand 仍然是 .bottom-row 的子节点,不需要为宽屏布局单独维护一份不同的 DOM 树),
+     这两个容器在桌面模式下用 display:contents"打散"成透明壳——它们自己不再生成盒子,
+     但子孙节点(.seat[data-zone]/#meSeat/#hand)会直接以 #game 的 grid item 身份参与
+     布局,而不是被"困"在各自父级的盒子里只能整体挪动。*/
+  @media (min-width:1024px){
+    #game.desktop-layout{
+      display:grid;
+      grid-template-columns:minmax(100px,180px) 1fr minmax(100px,180px);
+      grid-template-rows:repeat(8,auto);
+      column-gap:12px; row-gap:8px;
+      align-items:start;
+    }
+    #game.desktop-layout #oppRow{ display:contents; }
+    #game.desktop-layout .bottom-row{ display:contents; }
+    /* top: 最多3个(assignSeatZones 的 topCount 上限),横排在第1行,各占一列 */
+    #game.desktop-layout .seat[data-zone="top"][data-zone-index="0"]{ grid-column:1; grid-row:1; }
+    #game.desktop-layout .seat[data-zone="top"][data-zone-index="1"]{ grid-column:2; grid-row:1; }
+    #game.desktop-layout .seat[data-zone="top"][data-zone-index="2"]{ grid-column:3; grid-row:1; }
+    /* left: 最多2个,纵向排在最左列的第2/3行 */
+    #game.desktop-layout .seat[data-zone="left"][data-zone-index="0"]{ grid-column:1; grid-row:2; }
+    #game.desktop-layout .seat[data-zone="left"][data-zone-index="1"]{ grid-column:1; grid-row:3; }
+    /* right: 最多2个,纵向排在最右列的第2/3行 */
+    #game.desktop-layout .seat[data-zone="right"][data-zone-index="0"]{ grid-column:3; grid-row:2; }
+    #game.desktop-layout .seat[data-zone="right"][data-zone-index="1"]{ grid-column:3; grid-row:3; }
+    /* 中央出牌区:居中列,纵向跨第2/3行(和左右两列的座位卡对齐同一区块) */
+    #game.desktop-layout #tableStrip{ grid-column:2; grid-row:2 / span 2; align-self:center; }
+    /* 我:固定在座位区正下方,占满整行宽度 */
+    #game.desktop-layout #meSeat{ grid-column:1 / -1; grid-row:4; justify-self:center; }
+    /* 以下几项这一步只给"各占一整行、按顺序往下排"的兜底位置,不做内容密度优化
+       (信息条/手牌具体怎么摆留给下一步) */
+    #game.desktop-layout .panel.table{ grid-column:1 / -1; grid-row:5; }
+    #game.desktop-layout #myGeneral{ grid-column:1 / -1; grid-row:6; }
+    #game.desktop-layout .hand-label:not(#myGeneral){ grid-column:1 / -1; grid-row:7; }
+    #game.desktop-layout #hand{ grid-column:1 / -1; grid-row:8; }
+  }
+
   .hidden{display:none!important;}
 </style>
 </head>
@@ -1195,16 +1241,16 @@
      (或 index.html 里的 <style>/内联脚本)时都要顺手把这个数字改掉(改动原则见 CLAUDE.md)——
      手机浏览器对静态资源的缓存比电脑顽固得多,即使用户在自己那端硬刷新/关闭重开 App 也未必
      清得掉,查询参数不同=浏览器眼里是"新的" URL,必定重新请求,不依赖用户那侧的缓存策略。 -->
-<script src="config.js?v=147"></script>
-<script src="data.js?v=147"></script>
-<script src="room-lifecycle.js?v=147"></script>
-<script src="game.js?v=147"></script>
-<script src="weapons.js?v=147"></script>
-<script src="skills.js?v=147"></script>
-<script src="render.js?v=147"></script>
-<script src="render-table.js?v=147"></script>
-<script src="render-hand.js?v=147"></script>
-<script src="render-controls.js?v=147"></script>
-<script src="render-log.js?v=147"></script>
+<script src="config.js?v=148"></script>
+<script src="data.js?v=148"></script>
+<script src="room-lifecycle.js?v=148"></script>
+<script src="game.js?v=148"></script>
+<script src="weapons.js?v=148"></script>
+<script src="skills.js?v=148"></script>
+<script src="render.js?v=148"></script>
+<script src="render-table.js?v=148"></script>
+<script src="render-hand.js?v=148"></script>
+<script src="render-controls.js?v=148"></script>
+<script src="render-log.js?v=148"></script>
 </body>
 </html>

--- a/render.js
+++ b/render.js
@@ -258,7 +258,42 @@ function updateDesktopLayoutFlag(){
   if(gameEl) gameEl.classList.toggle('desktop-layout', desktopLayoutActive);
 }
 updateDesktopLayoutFlag();
-window.addEventListener('resize', updateDesktopLayoutFlag);
+// updateLogPanelHeight(): 第8步——日志面板的高度不能靠纯CSS的grid-row:span N声明
+// (最初的实现方式),因为"座位区+中央出牌区"这个组合的真实渲染底边,在不同人数/座位
+// 组合下,既可能比#tableStrip自身的渲染框更低(#tableStrip用align-self:center只占
+// 约64px、被更高的座位卡挤在中间时——8人局left/right都占满的场景),也可能反过来
+// (5人局这类left/right没坐满、tableStrip自身的最小高度反而撑出了原本没有座位卡的
+// 那一行,导致按grid行数对齐会比座位卡实际渲染的位置多出一截)。两个方向都可能出问题,
+// 靠纯CSS写死"跨几行"算不出正确结果,只能在JS里动态测量实际渲染出来的位置:取
+// "#oppTopRow/#oppRow 内所有座位卡的底边"(注意排除#meSeat——那是"我"的座位卡,
+// 已经合并到手牌那一行,不属于"座位区+中央出牌区"这个范围,如果不排除会把日志面板
+// 撑到页面最下面)和"#tableStrip自身底边"两者中更靠下(视口坐标更大)的那一个,减去
+// 日志面板自身的顶边,换算成一个具体像素高度,直接用内联style覆盖掉CSS里那份声明
+// (那份CSS的grid-row:1/span 3依然保留在index.html里,是这个JS计算失效时的兜底,
+// 比如极端边界下座位/tableStrip都不存在时这个函数会直接不设置任何内联高度)。
+function updateLogPanelHeight(){
+  const logEl = document.getElementById('logPanel');
+  if(!logEl) return;
+  if(!desktopLayoutActive){
+    logEl.style.height=''; // 窄屏下清掉可能残留的内联高度,让窄屏自己的CSS(max-height:132px等)重新生效
+    return;
+  }
+  let maxBottom = -Infinity;
+  document.querySelectorAll('#oppTopRow .seat, #oppRow .seat').forEach(el=>{
+    const r=el.getBoundingClientRect();
+    if(r.bottom>maxBottom) maxBottom=r.bottom;
+  });
+  const tableStripEl=document.getElementById('tableStrip');
+  if(tableStripEl){
+    const r=tableStripEl.getBoundingClientRect();
+    if(r.bottom>maxBottom) maxBottom=r.bottom;
+  }
+  if(maxBottom===-Infinity) return; // 理论边界:座位卡和tableStrip都不存在(尚未开局等),不设置,交给CSS兜底
+  const logTop = logEl.getBoundingClientRect().top;
+  const height = maxBottom - logTop;
+  if(height>0) logEl.style.height = height+'px';
+}
+window.addEventListener('resize', () => { updateDesktopLayoutFlag(); updateLogPanelHeight(); });
 
 // 常驻"关闭房间"按钮(cleanupRoom):只需要绑定一次,不放进render(g)里——这是一个固定
 // 挂在页面角落、不随游戏状态变化的元素,和 #helpBtn/#logBtn 同一类"页面初始化时绑一次"
@@ -1085,6 +1120,10 @@ function render(g){
   // 这个顺序影响(它是持久节点,不会被座位重绘销毁),但它的目标座位高亮逻辑必须在这里、
   // 座位元素已经是"这一轮最终版本"之后执行。
   renderTableCard(g);
+  // 第8步:座位卡分流挂载(#oppTopRow/#oppRow)和#tableStrip内容(renderTableCard)都已经
+  // 是这一轮最终状态之后,才能测量出正确的"座位区+中央出牌区"实际渲染高度,所以放在这两者
+  // 之后执行,和上面renderTableCard必须晚于座位重绘同一个理由。
+  updateLogPanelHeight();
 
   // phase pill + deck info
   const phaseName={lobby:'等待开始',draw:'摸牌阶段',play:'出牌阶段',discard:'弃牌阶段',respond:'响应阶段',duel:'决斗中',wuxie:'无懈响应',aoeResp:'群体响应',pick:'选牌',qilin:'弃坐骑',dying:'濒死求桃',guicai:'鬼才改判',tieqi:'铁骑判定',liegong:'烈弓',luoshen:'洛神判定',shuangxiongAsk:'双雄询问',xiaoguo:'骁果',xiaoguoChoice:'骁果选择',jiedaoChoice:'借刀杀人选择',wugu:'五谷丰登',qiaobianTurnStart:'巧变询问',qiaobianMove:'巧变移动',qinglong:'青龙偃月刀',hanbingAsk:'寒冰剑询问',hanbing:'寒冰剑弃牌',guanshi:'贯石斧',yijiAsk:'遗计询问',yijiAssign:'遗计分配',ganglieAsk:'刚烈询问',ganglieChoice:'刚烈惩罚',luoyiAsk:'裸衣询问',lirangAsk:'礼让询问',lirangRecover:'礼让回收',zhengyi:'争义询问',quhuRespond:'驱虎拼点',quhuDamageChoice:'驱虎伤害',fanjianSuit:'反间选花色',jiemingAsk:'节命询问',liuli:'流离询问',tianxiang:'天香询问',biyue:'闭月询问',pickingGeneral:'选将阶段',guanxingReview:'观星',shaOffsetChoice:'杀被抵消后的效果选择',mengjin:'猛进选择',zhijiChoice:'志继选择',tiaoxinChoice:'挑衅选择',tiaoxinDiscard:'挑衅弃牌',xunxunPick:'恂恂选择',wangxiAsk:'忘隙询问',over:'游戏结束'}[g.phase]||g.phase;

--- a/render.js
+++ b/render.js
@@ -209,6 +209,41 @@ checkLandscapeGate();
 window.addEventListener('resize', checkLandscapeGate);
 window.addEventListener('orientationchange', checkLandscapeGate);
 
+// ===== 宽屏桌面布局(desktop-layout-8p 第3步骨架) =====
+// assignSeatZones(playerCount, mySeat): 纯函数,把"我"以外的座位分到 top/left/right
+// 三个区域(见函数内注释),"我"自己固定 'me'。返回数组按座位号索引取值。
+// 分区规则(过渡态刻意从简,不追求精雕细琢):
+//   - 对手数(others=playerCount-1) <=3(即2~4人局): 全部 top
+//   - others===4(5人局): top3 + left1
+//   - others===5(6人局): top3 + left2
+//   - others>=6(7/8人局): top3 + left2 + right(others-5),7人局right1、8人局right2,
+//     同一条公式覆盖两档,不用为7人单独写分支。
+// 区内顺序按绝对座位号从小到大(不随mySeat旋转),保证同一输入永远同一输出。
+function assignSeatZones(playerCount, mySeat){
+  const zones = new Array(playerCount);
+  zones[mySeat] = 'me';
+  const others = [];
+  for(let s=0; s<playerCount; s++){
+    if(s!==mySeat) others.push(s);
+  }
+  const n = others.length;
+  let topCount, leftCount, rightCount;
+  if(n<=3){
+    topCount = n; leftCount = 0; rightCount = 0;
+  } else if(n===4){
+    topCount = 3; leftCount = 1; rightCount = 0;
+  } else if(n===5){
+    topCount = 3; leftCount = 2; rightCount = 0;
+  } else {
+    // n===6(7人局): top3+left2+right1；n===7(8人局): top3+left2+right2
+    topCount = 3; leftCount = 2; rightCount = n - 5;
+  }
+  let i = 0;
+  for(let k=0;k<topCount;k++)   zones[others[i++]] = 'top';
+  for(let k=0;k<leftCount;k++)  zones[others[i++]] = 'left';
+  for(let k=0;k<rightCount;k++) zones[others[i++]] = 'right';
+  return zones;
+}
 // 常驻"关闭房间"按钮(cleanupRoom):只需要绑定一次,不放进render(g)里——这是一个固定
 // 挂在页面角落、不随游戏状态变化的元素,和 #helpBtn/#logBtn 同一类"页面初始化时绑一次"
 // 的静态入口,不需要每次重绘都重新赋值 onclick(重复赋值同一个函数本身无害,但没必要)。

--- a/render.js
+++ b/render.js
@@ -689,11 +689,13 @@ function render(g){
   if(!(g.pending && g.pending.seat===mySeat &&
        (g.pending.type==='huashenPick' || g.pending.type==='huashenChangePickStart' || g.pending.type==='huashenChangePickEnd'))) resetHuashenPick();
   const oppRowEl=document.getElementById('oppRow');
+  const oppTopRowEl=document.getElementById('oppTopRow');
   const meSeatEl=document.getElementById('meSeat');
   // 骨架级重建(landscape-ui 第1阶段):.opp-row/#meSeat 各自独立容器,不再共用一个
   // #seats 网格——#tableCard 这次已经不是它们的子元素(见 index.html 的说明),两个
   // 容器整体清空重建没有"常驻子节点被连带销毁"这个历史包袱,可以直接 innerHTML=''。
-  oppRowEl.innerHTML=''; meSeatEl.innerHTML='';
+  // #oppTopRow(宽屏桌面布局专用,装zone==='top'的座位卡)同样每次整体清空重建。
+  oppRowEl.innerHTML=''; if(oppTopRowEl) oppTopRowEl.innerHTML=''; meSeatEl.innerHTML='';
   const seatN=(g.players||[]).length;
   // 对手在行内的左右顺序:从"我"的下家开始按回合顺序排列,单独一整行的横排场景下比旧版
   // "回合顺序上离我近的分左右两侧"更直觉,也不需要为不同人数维护不同的分侧规则。
@@ -1064,9 +1066,16 @@ function render(g){
     const meDOM = buildSeatDOM(mySeat);
     if(meDOM) meSeatEl.appendChild(meDOM);
   }
+  // 按zone分流挂载容器:zone==='top'时进#oppTopRow(宽屏专用,3张座位卡靠它自身的flex横排,
+  // 不再各自精确写grid-column/grid-row),其余(left/right,以及zones为null的窄屏/理论边界
+  // 情况)一律沿用原有的#oppRow(display:contents,靠座位卡自己的grid-column/grid-row精确
+  // 定位)。窄屏下zones恒为null,这个判断天然全部落到"其余"分支,和改动前的行为完全一致,
+  // 不会把任何座位误分流进#oppTopRow。
   oppOrder.forEach(i=>{
     const oppDOM = buildSeatDOM(i);
-    if(oppDOM) oppRowEl.appendChild(oppDOM);
+    if(!oppDOM) return;
+    if(zones && zones[i]==='top' && oppTopRowEl) oppTopRowEl.appendChild(oppDOM);
+    else oppRowEl.appendChild(oppDOM);
   });
   // 中央出牌区:和音效共用同一批 markCardSound 调用点、同一个 seq 序列。调用点必须放在
   // 座位卡片(.seat)全部重新创建完毕之后——曾经放在 render() 更靠前的位置(座位重绘之前),

--- a/render.js
+++ b/render.js
@@ -244,6 +244,22 @@ function assignSeatZones(playerCount, mySeat){
   for(let k=0;k<rightCount;k++) zones[others[i++]] = 'right';
   return zones;
 }
+// isDesktopLayout(): 宽屏(>=1024px)专属"座位按上/左/右/我四区摆位"布局是否启用的唯一
+// 开关——和 isPortrait()/checkLandscapeGate() 同一套写法,页面加载后立即算一次+注册
+// resize 监听动态更新,不是只在加载那一刻判断一次。desktopLayoutActive 这个标志位供
+// render() 决定要不要计算/写入 data-zone,后续步骤(日志面板挪位置/内容密度分支)会
+// 复用同一个标志位,不重复判断。#game 上的 desktop-layout class 只是把这个 JS 判断结果
+// 同步给 CSS(CSS 自己的 @media(min-width:1024px) 断点是双重保险,两边同时满足才生效)。
+let desktopLayoutActive = false;
+function isDesktopLayout(){ return window.innerWidth >= 1024; }
+function updateDesktopLayoutFlag(){
+  desktopLayoutActive = isDesktopLayout();
+  const gameEl = document.getElementById('game');
+  if(gameEl) gameEl.classList.toggle('desktop-layout', desktopLayoutActive);
+}
+updateDesktopLayoutFlag();
+window.addEventListener('resize', updateDesktopLayoutFlag);
+
 // 常驻"关闭房间"按钮(cleanupRoom):只需要绑定一次,不放进render(g)里——这是一个固定
 // 挂在页面角落、不随游戏状态变化的元素,和 #helpBtn/#logBtn 同一类"页面初始化时绑一次"
 // 的静态入口,不需要每次重绘都重新赋值 onclick(重复赋值同一个函数本身无害,但没必要)。
@@ -678,6 +694,20 @@ function render(g){
   } else {
     for(let k=0;k<seatN;k++) oppOrder.push(k); // mySeat 还未确定(理论边界):按原始顺序
   }
+  // 宽屏桌面布局(desktop-layout-8p 第3步):只在 desktopLayoutActive 时才计算/写入
+  // data-zone,窄屏时完全不算(assignSeatZones 需要 mySeat 非 null,理论边界下也不算)。
+  // zoneIndexBySeat 按 assignSeatZones 内部同一套"绝对座位号从小到大"的顺序派生
+  // (不是按 oppOrder 的回合顺序派生),保证和 assignSeatZones 声明的区内顺序一致,
+  // 不会出现"两套顺序各算各的"这种潜在不一致。
+  const zones = (desktopLayoutActive && mySeat!==null) ? assignSeatZones(seatN, mySeat) : null;
+  const zoneIndexBySeat = {};
+  if(zones){
+    const counters = {top:0, left:0, right:0};
+    for(let s=0;s<seatN;s++){
+      const z = zones[s];
+      if(z==='top'||z==='left'||z==='right') zoneIndexBySeat[s]=counters[z]++;
+    }
+  }
   // buildSeatDOM: 创建一个座位的完整 DOM 节点——视觉结构由 renderSeatCard 生成(纯粹
   // 描述"这张卡片长什么样"),随后接上目标选择/技能发动的交互逻辑(读一批客户端选牌/
   // 选目标状态机变量,和 render-hand.js 拆分时"这批状态不是手牌专属、不搬"是同一个
@@ -689,6 +719,10 @@ function render(g){
     // 骨架级重建后不再用 seatSlot/slot-*；酒诗等翻面状态用 .flipped 标记
     d.className='seat'+(g.turn===i&&g.started?' active':'')+(p.alive?'':' dead')+(i===mySeat?' me':'')+(p.faceup===false?' flipped':'');
     d.dataset.seat = i; // 供中央出牌区(renderTableCard)按座位号选中,高亮出牌方/目标座位用
+    if(zones){
+      d.dataset.zone = zones[i];
+      if(zoneIndexBySeat[i]!==undefined) d.dataset.zoneIndex = zoneIndexBySeat[i];
+    }
     d.innerHTML = renderSeatCard(g, i, i===mySeat);
     // targeting: clickable opponents when choosing a target card
     const meP=g.players[mySeat];

--- a/render.js
+++ b/render.js
@@ -490,12 +490,21 @@ function renderSeatCard(g, seat, isSelf){
   // "深色渐变垫底"这个新背景实测选的,不是沿用 cardFace 那套给浅色底设计的配色。
   const eq = p.equips || emptyEquips();
   const equipSlotsToShow = isSelf ? EQUIP_SLOTS : EQUIP_SLOTS.filter(s=>eq[s]);
+  // 内容密度分支(desktop-layout-8p 第5步):装备名文字本来就一直在渲染(不是这步新加的
+  // 文字节点),窄屏下靠 .erow 的 white-space:nowrap+ellipsis 截断长名字(如"雌雄双股剑"/
+  // "青龙偃月刀")。宽屏(isDesktopLayout())卡片更宽、且这是"内容密度分支"这个机制本身
+  // 要验证的地方,所以在这里读同一个已经维护好的开关(不新增基于 @media 的重复判断,
+  // 复用 render.js 顶部 checkLandscapeGate 同款写法引入的 isDesktopLayout()),给宽屏下
+  // 的这一行额外加 wide-name 这个 class,取消 ellipsis 截断、允许完整显示装备名
+  // (见 index.html 里 .seat-equip-bar .erow.wide-name 对应的纯 class 选择器,不建立新的
+  // @media 断点)。
+  const wideNameCls = isDesktopLayout() ? ' wide-name' : '';
   const equipRows = g.started ? equipSlotsToShow.map(s=>{
     const c = eq[s];
     const prefix = EQUIP_SLOT_ABBR[s];
     if(!c) return isSelf ? '<div class="erow empty-slot"><b>'+prefix+'</b> —</div>' : '';
     const eDesc = (getEquip(c.name) && getEquip(c.name).desc) || '';
-    return '<div class="erow filled" title="'+escapeHtml(eDesc)+'" onclick="event.stopPropagation();showEquipInfo(\''+c.name+'\')"><b>'+prefix+'</b> '+seatEquipFace(c)+escapeHtml(c.name)+'</div>';
+    return '<div class="erow filled'+wideNameCls+'" title="'+escapeHtml(eDesc)+'" onclick="event.stopPropagation();showEquipInfo(\''+c.name+'\')"><b>'+prefix+'</b> '+seatEquipFace(c)+escapeHtml(c.name)+'</div>';
   }).join('') : '';
   // 装备条(文字列本身)只在真的有内容时才渲染——对手一件装备都没有时不渲染这一块。
   const equipBar = equipRows ? '<div class="seat-equip-bar">'+equipRows+'</div>' : '';


### PR DESCRIPTION
## 背景
现有座位布局(.opp-row横排)在人数多时(4人以上)会挤成一长条,不适合宽屏
桌面场景。这次给>=1024px的宽屏窗口新增一套Grid布局:座位卡按上/左/右/我
四个区域摆位,同时把房间人数上限从3开放到8。

## 功能范围(5个commit，分别独立可读、独立可回滚)

**`8f68fb7`**：`assignSeatZones(playerCount,mySeat)`纯函数——把"我"以外
的座位分到top/left/right三个区域，"我"固定'me'，区内顺序按绝对座位号
从小到大（不随mySeat旋转）。

**`55e1901`**：`isDesktopLayout()`开关（和`isPortrait()`/
`checkLandscapeGate()`同一套写法：`window.innerWidth>=1024`判断+resize
监听动态更新）+ `@media(min-width:1024px)`下的Grid骨架——座位卡按
`data-zone`/`data-zone-index`精确定位，中央出牌区居中，"我"固定底部。
`#oppRow`/`.bottom-row`用`display:contents`打散成透明壳，不需要改动
现有DOM嵌套结构。

**`2b8db25`**：日志面板宽屏下挪到独立的第4列，纵向占满整个网格高度
（不和已经放right座位卡的第3列共用）。

**`9a10d32`**：装备栏内容密度分支——宽屏下装备名取消ellipsis截断、
允许换行完整显示（窄屏维持现状不变）。

**`135a114`**：`SEATS`从3改到8，支撑`assignSeatZones`的top3+left2+right2
满配。

## 需要注意的一点
**`assignSeatZones`对4~7人这几档过渡人数用的是简单插值规则（top先塞满
3个，剩下的依次进left/right），不是针对每一档人数精雕细琢过的结果**——
比如5人局是top3+left1，6人局是top3+left2，这类规则选得够用、不重叠，
但没有专门打磨"这几档人数下视觉上最好看的分布方式"。后续如果覺得某个
具体人数下的过渡效果不够好，可以单独迭代这个函数，不影响其它部分。

## 测试覆盖
纯手工/真实浏览器验证(未写自动化测试代码，均为Playwright驱动真实浏览器
+真实render/tx管线，非stub)：
- 3人/8人两组场景：座位骨架正确摆位，零重叠
- 5人/6人中间态过渡：程序化确认零重叠，视觉效果良好
- 日志面板：8人局宽屏下独立占据第4列、纵向占满、和座位卡零重叠；
  950x700窄屏(<1024)确认维持既有`position:fixed`浮动行为，用`git stash`
  切回改动前代码重跑同一测试坐标完全一致，确认无回归
- 装备栏密度分支：8人局宽屏下两个座位各装满4件装备(含最长武器名"青龙
  偃月刀"5字)，程序化确认矩形不越界、文字不截断；窄屏确认无`wide-name`
  class、维持既有截断行为
- 手机横屏(812x375)三人局完整流程：加入房间→开局→选将→摸牌→出牌，
  确认`desktop-layout`不生效、装备栏维持截断、日志面板维持既有隐藏
  规则(矮视口`@media(max-height:460px)`)、真实点击摸牌按钮成功推进阶段
- 全程零console报错

## 已知限制(不在本次修复范围)
无——这次纯粹是新增功能，未触及任何既有已知问题。