### PR TITLE
perf(ui): CORE-141 手机端不跑全屏Canvas飘牌动画(平板/桌面不变)

### DIFF
--- a/docs/progress-log-11.md
+++ b/docs/progress-log-11.md
@@ -178,3 +178,18 @@
 
   全量套件 **130/130** 通过。**cache-bust**：`bot-ai-bus.js` v409→410、`bot.js` v427→428。
 
+
+- **CORE-141(issue #194):手机端不跑全屏 Canvas 飘牌动画（平板/桌面维持现状）**：来源是一次手机/平板端耗电分析（分析基线 commit `b0affea`），这是分析中定位到的**最大单项持续耗电源**。**问题**：`game-bg.js` 的 `bgTick` 是全屏 Canvas 的 `requestAnimationFrame` 循环，**整局游戏期间无条件持续运行**（`room-lifecycle.js:90` 进房 `startGameBg()` 启动，只有 `backToLobby` 的 `stopGameBg()` 才停）——画布是 `#gameBgCanvas{position:fixed;inset:0}` 全视口且按 DPR 放大（手机横屏 844×390 @DPR3 → 2532×1170 ≈ 296 万像素），每帧全量 `clearRect`（60fps 下约 1.78 亿像素/秒，高刷屏翻倍），再画最多 18 张卡、每张都要 `save/translate/rotate` + 圆角路径 `fill`/`stroke` + **重设 `ctx.font`（尺寸随机，触发字体重新解析）** + `fillText`（canvas 文字是 2D 上下文最贵的操作之一）。而它是**纯装饰**——文件开头自己写着「纯视觉层：不读游戏状态」。已有的 `visibilitychange` 暂停是对的（切后台不耗电），所以耗的全是**正盯着屏幕玩**的时间，正好是用户反馈的场景。
+
+  **设备判定：这次改动最容易做错的地方**。本项目**强制引导手机横屏游玩**（`render.js` 的 `checkLandscapeGate`/`isPortrait`），所以手机的实际游玩形态是横屏、视口约 844×390——**宽度 844px 正好落在平板断点 `(min-width:641px) and (max-width:1199px)` 区间内**。若只按宽度判定，手机横屏会被当成平板，这次改动对真实使用场景**等于完全没生效**。CLAUDE.md 规则 22 与 CORE-122/CORE-126 都记录过「按宽度分档把手机横屏误当平板」这个已踩过多次的坑。因此新增的 `BG_PHONE_MEDIA_QUERIES` **逐字复用 `index.html` 里既有的两条手机断点**（`(max-width:640px)` 竖屏/窄屏、`(max-height:460px) and (orientation:landscape)` 横屏矮视口）取并集，不新造口径；`isPhoneLayout()` 优先 `matchMedia`，无 `matchMedia` 的环境退回等价宽高比较，且**兜底方向刻意选「不判成手机」**——判定不可靠时宁可维持改动前行为多跑动画，也不要误砍平板/桌面的既有效果。测试里有一条断言把这两条查询串**和 `index.html` 的 CSS 断点逐字对账**，防止以后改了 CSS 而 JS 侧不同步。
+
+  **实现结构**：把「该不该跑」的三个条件收敛到 `bgShouldAnimate()`（`bgRunning` 在对局中 / `!isPhoneLayout()` 非手机 / `!document.hidden` 页面可见），再由幂等的 `applyBgAnimationPolicy()` 统一启停；`startGameBg`/`visibilitychange`/`resize`/`orientationchange` 四处全部改走它，避免判定散落各处导致口径分叉。`visibilitychange` 的语义与改动前一致（隐藏则停、可见且在对局中则续），只是多叠了一条「手机不跑」。新增 `orientationchange` 监听：部分移动浏览器旋转时 `resize` 触发时机不可靠，`render.js` 的 `checkLandscapeGate` 也是两个都听，沿用同一惯例。
+
+  **顺带省下的内存**：`sizeBgCanvas()` 会把画布 backing store 按 DPR 放大分配（手机横屏 ≈ **11.8MB**）。手机端既然不画，这块内存就不该占——在正要优化的那类设备上白占 11.8MB 还会加剧 GC 压力。所以把 `sizeBgCanvas()` 也从 `startGameBg` 挪进策略里：不画时画布保持默认 300×150（几乎不占内存），真要开始画时 `applyBgAnimationPolicy` 会先补上。`resize`/`orientationchange` 里也只在 `bgShouldAnimate()` 为真时才重算尺寸，手机端反复旋转不会分配。
+
+  **刻意保留不动的两处**：①`fallingCards` 在停下来时**不清空**——切后台暂停时保留粒子状态是改动前的既有行为，回来能接着飘，不因为这次重构改掉（只有 `stopGameBg` 回大厅时才清）；②`stopGameBg` 除了停 rAF 还负责回大厅时清理残留的全屏特效视频（`deathFxVideo`/`lightningFxVideo`/`movieFxVideo` 的 `hideFxVideo`），**手机端不启动飘牌 ≠ 可以跳过这段清理**，测试里专门有一条断言钉住这一点。
+
+  **测试**：新增 `testclass/run_core141_phone_bg_test.js`（26 条），覆盖设备判定 8 种视口（含 ★手机横屏 844×390 这个宽度落在平板区间的关键场景、iPhone SE 横屏 667×375、小平板 800×600 高度 >460 不被横屏那条误命中）、无 `matchMedia` 兜底分支与 `matchMedia` 分支结论一致、**JS 判定与 `index.html` CSS 断点对账**、手机端不起 rAF 且不分配画布、平板/桌面逐字维持现状（起 rAF + 按 DPR 分配 2048×1536 / 1400×900）、切后台暂停与回前台恢复的既有行为不被破坏、手机端回前台也不恢复（手机限制优先于可见性）、回大厅后不恢复、桌面窗口拉窄跨断点停 rAF 并清屏、拉回桌面重新起 rAF 并补分配画布、`orientationchange` 同样触发重评估、手机端反复旋转不分配画布、`applyBgAnimationPolicy` 幂等、★手机端 `stopGameBg` 仍清理特效视频、粒子清空，外加**破坏性验证**（让 `isPhoneLayout` 恒 false = 关掉本次限制，确认手机端确实会起 rAF 并分配 2532×1170 ≈ 11.8MB 画布 = 改动前行为）。既有的 `run_fx_video_audio_test.js`(3/3)、`run_death_fx_detect_test.js`(8/8) **零改动通过**；全项目扫描确认只有新测试引用 `startGameBg`/`stopGameBg`/`bgTick`/`sizeBgCanvas`。
+
+  **判断轴**：`game-bg.js` 是纯视觉层、不读游戏状态、不进 `tx`、不触碰机器人决策链与 `pending` 流转，轴 A/B 均未命中，按规则 29 只需最小相关测试集；实际仍跑了全量 **133/133** 通过。**cache-bust**：`game-bg.js` v10→11。
+

--- a/game-bg.js
+++ b/game-bg.js
@@ -169,17 +169,92 @@ function bgTick(ts){
   }
 }
 
+// ============ CORE-141(issue #194):手机端不跑飘牌动画 ============
+// 【为什么】bgTick 是全屏 Canvas 的 rAF 循环,整局游戏期间持续运行:画布按 DPR 放大
+// (手机横屏 844x390 @DPR3 → 2532x1170 ≈ 296 万像素),每帧全量 clearRect,再画最多 18 张
+// 卡、每张都要重设 ctx.font 并 fillText(canvas 文字是 2D 上下文最贵的操作之一)。它是纯
+// 装饰(本文件开头就写着"纯视觉层:不读游戏状态"),却是手机端最大的单项持续耗电源。
+// 平板/桌面维持现状不变——只砍手机。
+//
+// 【设备判定为什么不能只看宽度 —— 这是这次改动最容易做错的地方】
+// 本项目强制引导手机横屏游玩(render.js 的 checkLandscapeGate/isPortrait),所以手机的
+// 实际游玩形态是横屏、视口约 844x390 —— **宽度 844px 正好落在平板断点
+// (min-width:641px) and (max-width:1199px) 区间内**。只按宽度判定的话,手机横屏会被当成
+// 平板,这次改动对真实使用场景等于完全没生效。CLAUDE.md 规则22 与 CORE-122/CORE-126 都
+// 记录过"按宽度分档把手机横屏误当平板"这个已经踩过多次的坑。
+//
+// 所以这里**逐字复用 index.html 里既有的两条手机断点**,不新造判定口径:
+//   @media (max-width:640px)                                   竖屏/窄屏
+//   @media (max-height:460px) and (orientation:landscape)      手机横屏矮视口
+// 两者取并集 = 手机。测试里有断言把这两条查询串和 index.html 的 CSS 断点对账,
+// 防止以后改了 CSS 而这里不同步。
+var BG_PHONE_MEDIA_QUERIES = [
+  '(max-width:640px)',
+  '(max-height:460px) and (orientation:landscape)'
+];
+function isPhoneLayout(){
+  if(typeof window === 'undefined') return false;
+  if(typeof window.matchMedia === 'function'){
+    for(var i = 0; i < BG_PHONE_MEDIA_QUERIES.length; i++){
+      if(window.matchMedia(BG_PHONE_MEDIA_QUERIES[i]).matches) return true;
+    }
+    return false;
+  }
+  // 旧浏览器/测试环境没有 matchMedia:退回等价的宽高比较(和上面两条断点同口径)。
+  // 安全方向选"不判成手机"——宁可多跑动画(维持改动前行为),也不要在判定不可靠时
+  // 把平板/桌面的既有效果误砍掉。
+  var w = window.innerWidth, h = window.innerHeight;
+  if(!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return false;
+  return w <= 640 || (h <= 460 && w > h);
+}
+// bgShouldAnimate:飘牌该不该跑。把三个条件收敛到一处,避免散落在 start/visibilitychange/
+// resize 三个地方各判一次导致口径分叉。
+//   bgRunning       —— 在对局中(进房 startGameBg 置真,回大厅 stopGameBg 置假)
+//   !isPhoneLayout()—— 非手机(本次新增的唯一一条限制)
+//   !document.hidden—— 页面可见(改动前就有的切后台暂停,逐字保留)
+function bgShouldAnimate(){
+  if(!bgRunning) return false;
+  if(isPhoneLayout()) return false;
+  if(typeof document !== 'undefined' && document.hidden) return false;
+  return true;
+}
+// applyBgAnimationPolicy:按 bgShouldAnimate() 的结论启停 rAF,幂等(重复调用不会起多个
+// 循环、也不会重复取消)。start/visibilitychange/resize 三处统一走它。
+function applyBgAnimationPolicy(){
+  if(bgShouldAnimate()){
+    if(!bgRafId){
+      // 起循环前先确保画布已按当前视口/DPR 分配好(手机端此前刻意没分配,见下方说明;
+      // 桌面窗口跨断点变宽时也要在这里补上)。sizeBgCanvas 幂等,重复调用无副作用。
+      sizeBgCanvas();
+      bgLastTs = 0;
+      bgRafId = requestAnimationFrame(bgTick);
+    }
+    return;
+  }
+  if(bgRafId){ cancelAnimationFrame(bgRafId); bgRafId = 0; }
+  // 停下来时把画面擦干净,避免最后一帧的飘牌定格在屏幕上(手机端进房即停、以及桌面窗口
+  // 被拉窄跨过 640px 断点这两种情况都会走到这里)。fallingCards 不清空:切后台暂停时
+  // 保留粒子状态是改动前的既有行为,回来能接着飘,不因为这次重构改掉。
+  if(bgCtx && bgCanvas) bgCtx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
+}
+
 // 启动飘牌（进房时调用）
 function startGameBg(){
   bgCanvas = document.getElementById('gameBgCanvas');
   if(!bgCanvas || typeof bgCanvas.getContext !== 'function') return;
   bgCtx = bgCanvas.getContext('2d');
   if(!bgCtx) return;
-  sizeBgCanvas();
   bgRunning = true;
   bgLastTs = 0;
   if(bgRafId) cancelAnimationFrame(bgRafId);
-  bgRafId = requestAnimationFrame(bgTick);
+  // CORE-141:改动前这里是无条件 sizeBgCanvas() + requestAnimationFrame(bgTick),
+  // 现在两件事都交给统一策略。
+  // 【为什么连 sizeBgCanvas 也要挪进策略里】它会把画布 backing store 按 DPR 放大分配:
+  // 手机横屏 844x390 @DPR3 → 2532x1170 ≈ 296 万像素 ≈ 11.8MB。手机端既然不画,这块内存
+  // 就不该占——在正要优化的那类设备上白占 11.8MB 还会加剧 GC 压力。不分配时画布保持
+  // 默认的 300x150,几乎不占内存;真要开始画时 applyBgAnimationPolicy 会先补上 sizeBgCanvas()。
+  // 非手机 + 页面可见的落点与改动前逐字一致(照样先 size 再立刻起一帧)。
+  applyBgAnimationPolicy();
 }
 
 // 停止并清空（回大厅时调用）
@@ -209,18 +284,26 @@ function sizeBgCanvas(){
 }
 
 // 页面隐藏暂停、恢复继续；窗口尺寸变化重适配
+// CORE-141:两处都改走 applyBgAnimationPolicy——语义与改动前一致(隐藏则停、可见且在对局
+// 中则续),只是多叠了一条"手机不跑"。
 if(typeof document !== 'undefined'){
-  document.addEventListener('visibilitychange', function(){
-    if(document.hidden){
-      if(bgRafId){ cancelAnimationFrame(bgRafId); bgRafId = 0; }
-    }else if(bgRunning && !bgRafId){
-      bgLastTs = 0;
-      bgRafId = requestAnimationFrame(bgTick);
-    }
-  });
+  document.addEventListener('visibilitychange', applyBgAnimationPolicy);
 }
 if(typeof window !== 'undefined'){
-  window.addEventListener('resize', sizeBgCanvas);
+  // CORE-141:resize/orientationchange 时除了重算画布尺寸,还要重新评估该不该跑——
+  // 桌面窗口拉宽拉窄会跨过 640px 断点,手机横竖屏切换会在两条手机断点之间移动。
+  // orientationchange 单独监听:部分移动浏览器旋转时 resize 触发时机不可靠(render.js
+  // 的 checkLandscapeGate 也是 resize + orientationchange 两个都听,同一惯例)。
+  // 只在真的会画时才重算画布尺寸(手机端不分配,理由见 startGameBg 里的说明);
+  // applyBgAnimationPolicy 内部在需要起循环时会自己补 sizeBgCanvas()。
+  window.addEventListener('resize', function(){
+    if(bgShouldAnimate()) sizeBgCanvas();
+    applyBgAnimationPolicy();
+  });
+  window.addEventListener('orientationchange', function(){
+    if(bgShouldAnimate()) sizeBgCanvas();
+    applyBgAnimationPolicy();
+  });
 }
 
 // ============ 角色死亡特效 ============

--- a/index.html
+++ b/index.html
@@ -2535,6 +2535,6 @@
 <script src="render-hand.js?v=394"></script>
 <script src="render-controls.js?v=421"></script>
 <script src="render-log.js?v=398"></script>
-<script src="game-bg.js?v=10"></script>
+<script src="game-bg.js?v=11"></script>
 </body>
 </html>

--- a/testclass/run_core141_phone_bg_test.js
+++ b/testclass/run_core141_phone_bg_test.js
@@ -1,0 +1,318 @@
+/**
+ * CORE-141(issue #194): 手机端不跑全屏 Canvas 飘牌动画,平板/桌面维持现状。
+ *
+ * 覆盖:
+ *  1. isPhoneLayout 的设备判定(含"手机横屏宽度落在平板区间"这个最容易做错的场景)
+ *  2. JS 判定与 index.html 的 CSS 手机断点对账(防止以后改了 CSS 而 JS 不同步)
+ *  3. 手机端 startGameBg 不起 rAF、不分配画布 backing store
+ *  4. 平板/桌面逐字维持现状(起 rAF + 分配画布)
+ *  5. 切后台暂停/回前台恢复(改动前的既有行为)不被破坏
+ *  6. 方向/尺寸变化时判定跟着变(两个方向都测)
+ *  7. stopGameBg 的特效视频清理在手机端仍然生效
+ *  8. 破坏性验证:断言有鉴别力
+ */
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+let passed = 0, failed = 0;
+function check(name, fn){
+  try { fn(); console.log('  PASS', name); passed++; }
+  catch(e){ console.log('  FAIL', name, '-', (e && e.message) || e); failed++; }
+}
+
+function mkVideo(){
+  return { muted:true, src:'', style:{visibility:'hidden'}, _removed:0,
+    play(){ return {catch(){}}; }, pause(){}, load(){},
+    addEventListener(){}, removeAttribute(){ this._removed++; } };
+}
+
+// mkEnv:构造一个可控视口的沙箱。viewport={w,h,dpr}；hasMatchMedia=false 可测兜底分支。
+function mkEnv(viewport, hasMatchMedia){
+  const vp = Object.assign({ w:1400, h:900, dpr:1 }, viewport||{});
+  const canvasCalls = { clearRect:0, setTransform:0 };
+  const canvas = {
+    width:300, height:150,           // <canvas> 未显式设置时的默认 backing store
+    clientWidth: vp.w, clientHeight: vp.h,
+    getContext(){ return {
+      clearRect(){ canvasCalls.clearRect++; },
+      setTransform(){ canvasCalls.setTransform++; },
+      save(){}, restore(){}, translate(){}, rotate(){}, beginPath(){}, moveTo(){},
+      lineTo(){}, quadraticCurveTo(){}, closePath(){}, fill(){}, stroke(){}, fillText(){},
+      set font(v){}, get font(){ return ''; }
+    }; }
+  };
+  const videos = { bgVideo:mkVideo(), deathFxVideo:mkVideo(), lightningFxVideo:mkVideo(), movieFxVideo:mkVideo() };
+  const listeners = { window:{}, document:{} };
+  let rafSeq = 0;
+  const raf = { pending:new Set(), cancels:0, requests:0 };
+
+  const context = {
+    Math, console, Number, String, Array, Object, Set,
+    document: {
+      hidden: false,
+      getElementById(id){ return id==='gameBgCanvas' ? canvas : (videos[id] || null); },
+      addEventListener(ev, fn){ (listeners.document[ev]=listeners.document[ev]||[]).push(fn); },
+      removeEventListener(){}, body:{}, createElement(){ return { style:{}, classList:{add(){},remove(){}}, appendChild(){}, }; },
+      querySelector(){ return null; }, querySelectorAll(){ return []; }
+    },
+    window: {
+      devicePixelRatio: vp.dpr, innerWidth: vp.w, innerHeight: vp.h,
+      addEventListener(ev, fn){ (listeners.window[ev]=listeners.window[ev]||[]).push(fn); },
+      removeEventListener(){},
+      matchMedia: hasMatchMedia===false ? undefined : function(q){
+        // 只实现本次用到的两条手机断点 + 解析它们的数值,行为等价于浏览器
+        const mw = q.match(/max-width:\s*(\d+)px/);
+        const mh = q.match(/max-height:\s*(\d+)px/);
+        const wantLandscape = /orientation:\s*landscape/.test(q);
+        let ok = true;
+        if(mw) ok = ok && (context.window.innerWidth <= Number(mw[1]));
+        if(mh) ok = ok && (context.window.innerHeight <= Number(mh[1]));
+        if(wantLandscape) ok = ok && (context.window.innerWidth > context.window.innerHeight);
+        return { matches: ok };
+      },
+      requestAnimationFrame(fn){ rafSeq++; raf.requests++; raf.pending.add(rafSeq); return rafSeq; },
+      cancelAnimationFrame(id){ raf.cancels++; raf.pending.delete(id); }
+    },
+    setTimeout(){ return 0; }, clearTimeout(){}
+  };
+  context.window.document = context.document;
+  context.requestAnimationFrame = context.window.requestAnimationFrame;
+  context.cancelAnimationFrame = context.window.cancelAnimationFrame;
+  context.global = context;
+  const sandbox = vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT,'game-bg.js'),'utf8'), sandbox, {filename:'game-bg.js'});
+  const get = expr => vm.runInContext(expr, sandbox);
+  const run = expr => vm.runInContext(expr, sandbox);
+  return { sandbox, get, run, canvas, videos, listeners, raf, canvasCalls,
+    setViewport(w,h){ context.window.innerWidth=w; context.window.innerHeight=h;
+      canvas.clientWidth=w; canvas.clientHeight=h; },
+    fire(target, ev){ (listeners[target][ev]||[]).forEach(f=>f()); } };
+}
+
+console.log('\n' + '='.repeat(60));
+console.log('  CORE-141:手机端不跑飘牌动画(平板/桌面不变)');
+console.log('='.repeat(60) + '\n');
+
+// ---------- 1. 设备判定 ----------
+check('手机竖屏(390x844) → 判为手机', () => {
+  const e = mkEnv({w:390,h:844,dpr:3});
+  if(e.get('isPhoneLayout()') !== true) throw new Error('应判为手机');
+});
+
+check('★手机横屏(844x390,宽度落在平板区间) → 仍判为手机(本次最易做错的场景)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  if(e.get('isPhoneLayout()') !== true)
+    throw new Error('844px 宽落在平板断点(641~1199)内,必须靠 max-height:460 那条判成手机');
+});
+
+check('iPhone SE 横屏(667x375) → 判为手机', () => {
+  const e = mkEnv({w:667,h:375,dpr:2});
+  if(e.get('isPhoneLayout()') !== true) throw new Error('应判为手机');
+});
+
+check('平板横屏(1024x768) → 不是手机', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  if(e.get('isPhoneLayout()') !== false) throw new Error('平板不应判为手机');
+});
+
+check('平板竖屏(768x1024) → 不是手机', () => {
+  const e = mkEnv({w:768,h:1024,dpr:2});
+  if(e.get('isPhoneLayout()') !== false) throw new Error('平板不应判为手机');
+});
+
+check('小平板(800x600,高度>460) → 不是手机', () => {
+  const e = mkEnv({w:800,h:600,dpr:2});
+  if(e.get('isPhoneLayout()') !== false) throw new Error('高度 600>460,不该被横屏那条命中');
+});
+
+check('桌面(1400x900) → 不是手机', () => {
+  const e = mkEnv({w:1400,h:900,dpr:1});
+  if(e.get('isPhoneLayout()') !== false) throw new Error('桌面不应判为手机');
+});
+
+check('无 matchMedia 的环境:兜底分支与 matchMedia 分支结论一致', () => {
+  [[390,844,true],[844,390,true],[667,375,true],[1024,768,false],[800,600,false],[1400,900,false]]
+    .forEach(([w,h,want]) => {
+      const e = mkEnv({w,h,dpr:2}, false);
+      if(e.get('isPhoneLayout()') !== want)
+        throw new Error(w+'x'+h+' 兜底判定应为 '+want+',实际 '+e.get('isPhoneLayout()'));
+    });
+});
+
+// ---------- 2. 与 CSS 断点对账 ----------
+check('JS 判定用的媒体查询与 index.html 的手机断点逐字对账', () => {
+  const html = fs.readFileSync(path.join(ROOT,'index.html'),'utf8');
+  const e = mkEnv();
+  const qs = e.get('JSON.stringify(BG_PHONE_MEDIA_QUERIES)');
+  const list = JSON.parse(qs);
+  if(list.length !== 2) throw new Error('应为两条断点,实际 ' + qs);
+  // CSS 里这两条断点必须真实存在——否则说明 CSS 改了而这里没同步
+  const norm = t => t.replace(/\s+/g,'');
+  if(norm(html).indexOf(norm('@media (max-width:640px)')) < 0)
+    throw new Error('index.html 里找不到手机竖屏断点 @media (max-width:640px)');
+  if(norm(html).indexOf(norm('@media (max-height:460px) and (orientation:landscape)')) < 0)
+    throw new Error('index.html 里找不到手机横屏断点 @media (max-height:460px) and (orientation:landscape)');
+  list.forEach(q => {
+    if(norm(html).indexOf(norm(q)) < 0)
+      throw new Error('JS 用的查询「'+q+'」在 index.html 里不存在,两边口径已分叉');
+  });
+});
+
+// ---------- 3. 手机端:不起 rAF、不分配画布 ----------
+check('手机端 startGameBg:不起 rAF', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()');
+  if(e.get('bgRafId') !== 0) throw new Error('手机端不应起 rAF,bgRafId=' + e.get('bgRafId'));
+  if(e.raf.requests !== 0) throw new Error('不应调用 requestAnimationFrame,实际 ' + e.raf.requests + ' 次');
+});
+
+check('手机端 startGameBg:不分配画布 backing store(省 ~11.8MB)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()');
+  if(e.canvas.width !== 300 || e.canvas.height !== 150)
+    throw new Error('手机端画布应保持默认 300x150,实际 ' + e.canvas.width + 'x' + e.canvas.height
+      + '(844x390@DPR3 会分配 2532x1170 ≈ 11.8MB)');
+});
+
+check('手机端 bgRunning 仍为 true(在对局中这个语义不变,只是不画)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()');
+  if(e.get('bgRunning') !== true) throw new Error('bgRunning 应为 true');
+});
+
+// ---------- 4. 平板/桌面:逐字维持现状 ----------
+check('平板 startGameBg:照常起 rAF(与改动前一致)', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  e.run('startGameBg()');
+  if(!e.get('bgRafId')) throw new Error('平板应起 rAF');
+  if(e.raf.requests !== 1) throw new Error('应恰调用 1 次 rAF,实际 ' + e.raf.requests);
+});
+
+check('平板 startGameBg:照常按 DPR 分配画布(与改动前一致)', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  e.run('startGameBg()');
+  if(e.canvas.width !== 2048 || e.canvas.height !== 1536)
+    throw new Error('应为 1024*2 x 768*2,实际 ' + e.canvas.width + 'x' + e.canvas.height);
+});
+
+check('桌面 startGameBg:照常起 rAF + 分配画布', () => {
+  const e = mkEnv({w:1400,h:900,dpr:1});
+  e.run('startGameBg()');
+  if(!e.get('bgRafId')) throw new Error('桌面应起 rAF');
+  if(e.canvas.width !== 1400 || e.canvas.height !== 900)
+    throw new Error('实际 ' + e.canvas.width + 'x' + e.canvas.height);
+});
+
+// ---------- 5. 切后台/回前台(既有行为不被破坏) ----------
+check('平板:切后台暂停 rAF、回前台恢复(改动前的既有行为)', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  e.run('startGameBg()');
+  if(!e.get('bgRafId')) throw new Error('前置:应已起 rAF');
+  e.sandbox.document.hidden = true;
+  e.fire('document','visibilitychange');
+  if(e.get('bgRafId') !== 0) throw new Error('切后台应停 rAF');
+  e.sandbox.document.hidden = false;
+  e.fire('document','visibilitychange');
+  if(!e.get('bgRafId')) throw new Error('回前台应恢复 rAF');
+});
+
+check('手机:回前台也不恢复 rAF(手机限制优先于可见性)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()');
+  e.sandbox.document.hidden = true;  e.fire('document','visibilitychange');
+  e.sandbox.document.hidden = false; e.fire('document','visibilitychange');
+  if(e.get('bgRafId') !== 0) throw new Error('手机端任何时候都不该起 rAF');
+});
+
+check('回大厅后(bgRunning=false)回前台不恢复 rAF', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  e.run('startGameBg()'); e.run('stopGameBg()');
+  e.sandbox.document.hidden = false;
+  e.fire('document','visibilitychange');
+  if(e.get('bgRafId') !== 0) throw new Error('不在对局中不该起 rAF');
+});
+
+// ---------- 6. 方向/尺寸变化 ----------
+check('桌面窗口拉窄到手机宽度 → 停 rAF 并清屏', () => {
+  const e = mkEnv({w:1400,h:900,dpr:1});
+  e.run('startGameBg()');
+  if(!e.get('bgRafId')) throw new Error('前置:应已起 rAF');
+  const clearsBefore = e.canvasCalls.clearRect;
+  e.setViewport(500, 900);           // 宽度 500 ≤ 640 → 手机
+  e.fire('window','resize');
+  if(e.get('bgRafId') !== 0) throw new Error('拉窄到手机宽度后应停 rAF');
+  if(e.canvasCalls.clearRect <= clearsBefore) throw new Error('停下来时应清一次屏,避免最后一帧定格');
+});
+
+check('窗口从手机宽度拉回桌面 → 重新起 rAF 并补分配画布', () => {
+  const e = mkEnv({w:500,h:900,dpr:2});
+  e.run('startGameBg()');
+  if(e.get('bgRafId') !== 0) throw new Error('前置:手机宽度不应起 rAF');
+  if(e.canvas.width !== 300) throw new Error('前置:不应分配画布');
+  e.setViewport(1400, 900);
+  e.fire('window','resize');
+  if(!e.get('bgRafId')) throw new Error('拉回桌面应重新起 rAF');
+  if(e.canvas.width !== 2800 || e.canvas.height !== 1800)
+    throw new Error('起循环前应补 sizeBgCanvas,实际 ' + e.canvas.width + 'x' + e.canvas.height);
+});
+
+check('orientationchange 同样触发重新评估(部分移动浏览器 resize 时机不可靠)', () => {
+  const e = mkEnv({w:1400,h:900,dpr:1});
+  e.run('startGameBg()');
+  e.setViewport(844, 390);
+  e.fire('window','orientationchange');
+  if(e.get('bgRafId') !== 0) throw new Error('orientationchange 后应按手机停掉');
+});
+
+check('手机端 resize 不会分配画布(反复旋转也不占内存)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()');
+  e.setViewport(390, 844); e.fire('window','orientationchange');
+  e.setViewport(844, 390); e.fire('window','orientationchange');
+  if(e.canvas.width !== 300 || e.canvas.height !== 150)
+    throw new Error('手机端反复旋转仍不应分配画布,实际 ' + e.canvas.width + 'x' + e.canvas.height);
+});
+
+check('applyBgAnimationPolicy 幂等:重复调用不会起多个循环', () => {
+  const e = mkEnv({w:1400,h:900,dpr:1});
+  e.run('startGameBg()');
+  const n = e.raf.requests;
+  e.run('applyBgAnimationPolicy(); applyBgAnimationPolicy(); applyBgAnimationPolicy();');
+  if(e.raf.requests !== n) throw new Error('已在运行时不该重复起循环,多起了 ' + (e.raf.requests-n) + ' 次');
+});
+
+// ---------- 7. stopGameBg 的特效视频清理 ----------
+check('★手机端 stopGameBg 仍然清理残留的全屏特效视频(不启动飘牌≠可以跳过清理)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()');
+  e.run('stopGameBg()');
+  ['deathFxVideo','lightningFxVideo','movieFxVideo'].forEach(id => {
+    if(e.videos[id]._removed < 1) throw new Error(id + ' 应被 hideFxVideo 清理(removeAttribute("src"))');
+    if(e.videos[id].style.visibility !== 'hidden') throw new Error(id + ' 应被隐藏');
+  });
+});
+
+check('手机端 stopGameBg 后 bgRunning=false、飘牌粒子清空', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('startGameBg()'); e.run('stopGameBg()');
+  if(e.get('bgRunning') !== false) throw new Error('bgRunning 应为 false');
+  if(e.get('fallingCards.length') !== 0) throw new Error('粒子应清空');
+});
+
+// ---------- 8. 破坏性验证 ----------
+check('破坏性验证:让 isPhoneLayout 恒 false(=关掉本次限制),手机端断言确实会红', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('isPhoneLayout = function(){ return false; };');
+  e.run('startGameBg()');
+  if(e.get('bgRafId') === 0)
+    throw new Error('关掉限制后手机端仍不起 rAF,说明手机端断言没有鉴别力');
+  if(e.canvas.width !== 2532 || e.canvas.height !== 1170)
+    throw new Error('关掉限制后应按 DPR 分配 2532x1170(= 改动前的行为),实际 '
+      + e.canvas.width + 'x' + e.canvas.height);
+  console.log('       ↳ 关掉限制后手机端确实会起 rAF 并分配 2532x1170 ≈ 11.8MB 画布(= 改动前行为)');
+});
+
+console.log('\n结果: ' + passed + ' 通过, ' + failed + ' 失败');
+if(failed > 0) process.exit(1);


### PR DESCRIPTION
perf(ui): CORE-141 手机端不跑全屏Canvas飘牌动画(平板/桌面不变)

bgTick 是全屏 Canvas 的 rAF 循环,整局游戏期间无条件持续运行:画布按 DPR 放大
(手机横屏 844x390 @DPR3 → 2532x1170 ≈ 296万像素),每帧全量 clearRect,再画最多
18 张卡、每张重设 ctx.font 并 fillText。纯装饰,却是手机端最大的单项持续耗电源。

设备判定不能只看宽度:本项目强制引导手机横屏,手机实际视口约 844x390,宽度正好
落在平板断点(641~1199px)内——只按宽度判定的话这次改动对真实场景等于没生效
(CLAUDE.md 规则22 / CORE-122 / CORE-126 都记过这个坑)。因此逐字复用 index.html
既有的两条手机断点取并集,并在测试里与 CSS 对账,防止以后两边分叉。

实现:把"该不该跑"的三个条件(在对局中/非手机/页面可见)收敛到 bgShouldAnimate(),
由幂等的 applyBgAnimationPolicy() 统一启停;start/visibilitychange/resize/
orientationchange 四处全走它。visibilitychange 语义与改动前一致,只多叠"手机不跑"。

顺带把 sizeBgCanvas() 也挪进策略:手机端不画就不分配画布 backing store,
省 ~11.8MB 内存并减轻 GC 压力;真要开始画时策略里会先补上。

刻意保留不动:切后台暂停时 fallingCards 不清空(既有行为);stopGameBg 的特效视频
清理在手机端仍然生效(不启动飘牌≠可以跳过清理),测试有专门断言。

新增 testclass/run_core141_phone_bg_test.js(26 条,含破坏性验证)
既有 run_fx_video_audio_test(3/3)、run_death_fx_detect_test(8/8) 零改动通过。
全量 133/133。cache-bust: game-bg v11

Closes #194

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
