### PR TITLE
perf(ui): CORE-144 手机端不播大厅背景视频(平板/桌面不变)

### DIFF
--- a/docs/progress-log-11.md
+++ b/docs/progress-log-11.md
@@ -193,3 +193,18 @@
 
   **判断轴**：`game-bg.js` 是纯视觉层、不读游戏状态、不进 `tx`、不触碰机器人决策链与 `pending` 流转，轴 A/B 均未命中，按规则 29 只需最小相关测试集；实际仍跑了全量 **133/133** 通过。**cache-bust**：`game-bg.js` v10→11。
 
+
+- **CORE-144(issue #197):手机端不播大厅背景视频（平板/桌面维持现状）**：同一次手机/平板耗电分析的第四项，紧接 CORE-141 之后做，两者共用同一套设备判定。**问题**：`<video id="bgVideo" autoplay muted loop>` 里的 `bg-1/2/3.mp4` 各 **5~6MB**、`loop` 无限循环。视频硬件解码是持续性功耗负载，而大厅正是「等朋友进房」的场景，可能停留好几分钟、期间用户往往只是盯着屏幕等——纯装饰性的动态背景在这里性价比最低；而且每次进大厅 `pickRandomBgVideo()` 都会随机换一个重新加载，手机上还额外吃 5~6MB 移动流量。
+
+  **范围与判定**：只砍手机，平板/桌面维持现状——和 CORE-141 同一取舍，**直接复用 CORE-141 已经落地并测过的 `isPhoneLayout()`**（`(max-width:640px)` ∪ `(max-height:460px) and (orientation:landscape)`，与 `index.html` CSS 断点逐字同源），不新造第二套判定。新增的 `shouldPlayLobbyVideo()` 只是它的一层语义包装。`isPhoneLayout` 定义在文件下方而 `pickRandomBgVideo` 在上方，函数声明提升保证调用时机没问题（文件末尾那次「加载即执行」的 `pickRandomBgVideo()` 更是在全部定义之后）。
+
+  **手机端的具体效果**：**不设置 `v.src`** —— 这是省流量的关键，只 `pause` 而不管 `src` 的话浏览器仍会把整个文件拉下来；不播放；并隐藏视频与遮罩层，回到 `body` 本来的渐变默认背景——**和进房时 `pauseBgVideo()` 的视觉落点完全一致**，不是一个新的空白状态。新增的 `hideLobbyVideo()` 还会在 `src` 已存在时一并释放（`removeAttribute('src')` + `load()`，沿用 `hideFxVideo` 的既有做法），覆盖「先按平板加载过、后来跨断点变成手机」这种情况，避免已下载的那份继续占内存；**只在确实设过 `src` 时才调 `load()`**，否则部分浏览器会报无源警告。
+
+  **`resumeBgVideo` 里遮罩的处理**：手机端不显示 `#bgVeil`。遮罩（`.bg-veil` 的深色渐变）本来是用来压暗视频、保证前景文字可读的，没有视频时它只会把默认渐变背景再无谓压暗一层。
+
+  **刻意一个字节都没碰的两处**：①**`unmuteBgVideo`/`unlockFxAudio` 音轨解锁**——它除了大厅视频，还负责解锁死亡/闪电/过场三条全屏特效的音轨（`FX_VIDEO_IDS` 包含 `bgVideo` 但不止它），**手机端不播大厅视频不等于可以跳过那套解锁**，否则手机上所有特效都会变哑；测试里有专门断言（首次交互后三条特效视频必须都 `muted===false`）。②**`pauseBgVideo`**——它对所有设备行为一致，不需要也不应该引入设备判定，测试里用源码断言钉住它没被塞进 `shouldPlayLobbyVideo`/`isPhoneLayout`。
+
+  **测试**：新增 `testclass/run_core144_lobby_video_test.js`（17 条），覆盖手机横屏/竖屏不设 `src`、不 `play`、视频与遮罩都收起；平板/桌面逐字维持现状（设 `src` + `load` + `play` + 视频可见）；小平板 800×600（高度 >460）不被手机横屏那条误命中；进房/回大厅往返（平板正常恢复、手机反复往返 5 次仍不播不下载）；★音轨解锁不被破坏；`applyFxAudio` 仍生效；已设过 `src` 时会被释放、从未设过时不调 `load()`；`pauseBgVideo` 源码未被触碰；外加**破坏性验证**（让 `shouldPlayLobbyVideo` 恒 true = 关掉本次限制，确认手机端确实会加载 `bg-N.mp4` 并播放 = 改动前行为）。既有 `run_fx_video_audio_test.js`(3/3)、`run_death_fx_detect_test.js`(8/8)、`run_core141_phone_bg_test.js`(26/26) **全部零改动通过**。
+
+  **判断轴**：纯视觉层，不读游戏状态、不进 `tx`、不触碰机器人决策链与 `pending` 流转，轴 A/B 均未命中；实际仍跑了全量 **134/134** 通过。**cache-bust**：`game-bg.js` v11→12。**未做真机实测**：验证全部来自可控视口的 vm 沙箱（是否设 `src`/是否 `play`/可见性/音轨解锁），省电与省流量的方向是确定的（手机端从「5~6MB 下载 + 持续硬件解码」变成「零下载零解码」），但具体幅度需真机确认。
+

--- a/game-bg.js
+++ b/game-bg.js
@@ -10,10 +10,49 @@ var BG_VIDEOS = [
   'assets/video/bg-3.mp4'
 ];
 
+// ============ CORE-144(issue #197):手机端不播大厅背景视频 ============
+// 【为什么】<video id="bgVideo" autoplay muted loop> 里的 bg-1/2/3.mp4 各 5~6MB,loop
+// 无限循环。视频硬件解码是持续性功耗负载,而大厅是"等朋友进房"的场景,可能停留好几分钟,
+// 期间用户往往只是盯着屏幕等——纯装饰性的动态背景在这里性价比最低。而且每次进大厅
+// pickRandomBgVideo() 都会随机换一个重新加载,手机上还额外吃 5~6MB 移动流量。
+//
+// 【范围:只砍手机,平板/桌面维持现状】和 CORE-141(#194)同一取舍与同一判定函数
+// (isPhoneLayout,定义在本文件下方;函数声明会提升,这里调用时机没问题)。**不要只按宽度
+// 判定**——本项目强制引导手机横屏,视口约 844x390,宽度正好落在平板断点(641~1199px)内,
+// 只看宽度会把手机横屏误判成平板,详见 isPhoneLayout 处的完整说明与 CLAUDE.md 规则22。
+//
+// 【手机端的效果】不设置 v.src(**连下载都不发生**,这是省流量的关键——只 pause 不设 src
+// 仍会把整个文件拉下来)、不播放,并隐藏视频与遮罩层,回到 body 本来的渐变默认背景——
+// 和进房时 pauseBgVideo() 的视觉落点完全一致,不是一个新的空白状态。
+//
+// 【刻意不碰音轨解锁】unmuteBgVideo/unlockFxAudio 一个字节不动:它除了大厅视频,还负责
+// 解锁死亡/闪电/过场三条全屏特效的音轨(FX_VIDEO_IDS 包含 bgVideo 但不止它),手机端
+// 不播大厅视频**不等于**可以跳过那套解锁,否则手机上所有特效都会变成哑的。
+function shouldPlayLobbyVideo(){
+  return !(typeof isPhoneLayout === 'function' && isPhoneLayout());
+}
+// hideLobbyVideo:把大厅视频与遮罩收起来,回到 body 默认渐变背景。
+// 视觉落点与 pauseBgVideo 一致;区别是这里还会在 src 已存在时一并释放(removeAttribute
+// + load(),同 hideFxVideo 的既有做法),避免已经下载的那份继续占内存。
+function hideLobbyVideo(v){
+  if(!v) return;
+  if(typeof v.pause === 'function') v.pause();
+  v.style.visibility = 'hidden';
+  // 只在确实设过 src 时才释放:没设过就调 load() 会在部分浏览器里报无源警告。
+  if(v.getAttribute && v.getAttribute('src')){
+    if(typeof v.removeAttribute === 'function') v.removeAttribute('src');
+    if(typeof v.load === 'function') v.load();
+  }
+  var veil = document.getElementById('bgVeil');
+  if(veil) veil.style.visibility = 'hidden';
+}
+
 // 回大厅时随机选一个视频并尝试播放（muted+playsinline 保证自动播放策略通过）
 function pickRandomBgVideo(){
   var v = document.getElementById('bgVideo');
   if(!v) return;
+  // CORE-144:手机端直接收起,不设 src、不下载、不播放。
+  if(!shouldPlayLobbyVideo()){ hideLobbyVideo(v); return; }
   v.style.visibility = 'visible'; // 恢复可见(进房时被隐藏,避免停帧像卡住)
   v.src = BG_VIDEOS[Math.floor(Math.random() * BG_VIDEOS.length)];
   if(typeof v.load === 'function') v.load();
@@ -36,6 +75,9 @@ function pauseBgVideo(){
 
 // 回大厅恢复：显示遮罩、随机换一个视频继续播
 function resumeBgVideo(){
+  // CORE-144:手机端不放遮罩(遮罩是用来压暗视频的,没有视频时它只会把默认渐变背景
+  // 再压暗一层),直接交给 pickRandomBgVideo 走收起分支。
+  if(!shouldPlayLobbyVideo()){ pickRandomBgVideo(); return; }
   var veil = document.getElementById('bgVeil');
   if(veil) veil.style.visibility = 'visible';
   pickRandomBgVideo();

--- a/index.html
+++ b/index.html
@@ -2535,6 +2535,6 @@
 <script src="render-hand.js?v=394"></script>
 <script src="render-controls.js?v=421"></script>
 <script src="render-log.js?v=398"></script>
-<script src="game-bg.js?v=11"></script>
+<script src="game-bg.js?v=12"></script>
 </body>
 </html>

--- a/testclass/run_core144_lobby_video_test.js
+++ b/testclass/run_core144_lobby_video_test.js
@@ -1,0 +1,249 @@
+/**
+ * CORE-144(issue #197): 手机端不播大厅背景视频(平板/桌面维持现状)。
+ *
+ * 覆盖:
+ *  1. 手机端:不设 src(连下载都不发生)、不播放、视频与遮罩都收起
+ *  2. 平板/桌面:逐字维持现状(设 src + load + play + 显示视频与遮罩)
+ *  3. 进房/回大厅往返:手机端始终不播,平板端照常恢复
+ *  4. ★音轨解锁不被破坏(手机端不播大厅视频 ≠ 特效变哑)
+ *  5. 已下载过的 src 会被释放(跨断点时不残留内存)
+ *  6. pauseBgVideo 既有行为不变
+ *  7. 破坏性验证:断言有鉴别力
+ */
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+let passed = 0, failed = 0;
+function check(name, fn){
+  try { fn(); console.log('  PASS', name); passed++; }
+  catch(e){ console.log('  FAIL', name, '-', (e && e.message) || e); failed++; }
+}
+
+function mkVideo(){
+  const attrs = {};
+  return {
+    muted: true, _src: '', style: { visibility: 'hidden' },
+    _plays: 0, _pauses: 0, _loads: 0, _removes: 0,
+    get src(){ return this._src; },
+    set src(v){ this._src = v; attrs.src = v; },
+    getAttribute(k){ return k==='src' ? (attrs.src || '') : (attrs[k] || null); },
+    setAttribute(k,v){ attrs[k]=v; if(k==='src') this._src=v; },
+    removeAttribute(k){ delete attrs[k]; if(k==='src') this._src=''; this._removes++; },
+    play(){ this._plays++; return { catch(){} }; },
+    pause(){ this._pauses++; },
+    load(){ this._loads++; },
+    addEventListener(){}
+  };
+}
+
+function mkEnv(viewport){
+  const vp = Object.assign({ w:1400, h:900, dpr:1 }, viewport||{});
+  const els = {
+    bgVideo: mkVideo(), deathFxVideo: mkVideo(),
+    lightningFxVideo: mkVideo(), movieFxVideo: mkVideo(),
+    bgVeil: { style:{ visibility:'hidden' } },
+    gameBgCanvas: { width:300, height:150, clientWidth:vp.w, clientHeight:vp.h,
+      getContext(){ return { clearRect(){}, setTransform(){}, save(){}, restore(){},
+        translate(){}, rotate(){}, beginPath(){}, moveTo(){}, lineTo(){},
+        quadraticCurveTo(){}, closePath(){}, fill(){}, stroke(){}, fillText(){},
+        set font(v){}, get font(){ return ''; } }; } }
+  };
+  const docListeners = {};
+  const context = {
+    Math, console, Number, String, Array, Object, Set, JSON,
+    document: {
+      hidden:false,
+      getElementById(id){ return els[id] || null; },
+      addEventListener(ev,fn){ (docListeners[ev]=docListeners[ev]||[]).push(fn); },
+      removeEventListener(ev,fn){
+        if(!docListeners[ev]) return;
+        docListeners[ev] = docListeners[ev].filter(f => f!==fn);
+      },
+      body:{}, createElement(){ return { style:{}, classList:{add(){},remove(){}}, appendChild(){} }; },
+      querySelector(){ return null; }, querySelectorAll(){ return []; }
+    },
+    window: {
+      devicePixelRatio:vp.dpr, innerWidth:vp.w, innerHeight:vp.h,
+      addEventListener(){}, removeEventListener(){},
+      matchMedia(q){
+        const mw = q.match(/max-width:\s*(\d+)px/);
+        const mh = q.match(/max-height:\s*(\d+)px/);
+        const wantLandscape = /orientation:\s*landscape/.test(q);
+        let ok = true;
+        if(mw) ok = ok && (context.window.innerWidth <= Number(mw[1]));
+        if(mh) ok = ok && (context.window.innerHeight <= Number(mh[1]));
+        if(wantLandscape) ok = ok && (context.window.innerWidth > context.window.innerHeight);
+        return { matches: ok };
+      },
+      requestAnimationFrame(){ return 1; }, cancelAnimationFrame(){}
+    },
+    setTimeout(){ return 0; }, clearTimeout(){}
+  };
+  context.window.document = context.document;
+  context.requestAnimationFrame = context.window.requestAnimationFrame;
+  context.cancelAnimationFrame = context.window.cancelAnimationFrame;
+  context.global = context;
+  const sandbox = vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(ROOT,'game-bg.js'),'utf8'), sandbox, {filename:'game-bg.js'});
+  return {
+    sandbox, els, docListeners,
+    get: e => vm.runInContext(e, sandbox),
+    run: e => vm.runInContext(e, sandbox),
+    fireDoc(ev){ (docListeners[ev]||[]).slice().forEach(f => f()); }
+  };
+}
+
+console.log('\n' + '='.repeat(60));
+console.log('  CORE-144:手机端不播大厅背景视频(平板/桌面不变)');
+console.log('='.repeat(60) + '\n');
+
+// 注意:game-bg.js 末尾有 `if(typeof document!=='undefined') pickRandomBgVideo();`
+// ——加载即执行一次,所以下面多数用例直接看加载后的状态即可(等同"页面首次进大厅")。
+
+// ---------- 1. 手机端 ----------
+check('手机横屏(844x390):页面加载后不设 src(连下载都不发生)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  if(e.els.bgVideo.src) throw new Error('不应设置 src,实际 ' + e.els.bgVideo.src);
+});
+
+check('手机横屏:不调用 play()', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  if(e.els.bgVideo._plays !== 0) throw new Error('不应播放,实际 play ' + e.els.bgVideo._plays + ' 次');
+});
+
+check('手机竖屏(390x844):同样不设 src、不播放', () => {
+  const e = mkEnv({w:390,h:844,dpr:3});
+  if(e.els.bgVideo.src) throw new Error('不应设置 src');
+  if(e.els.bgVideo._plays !== 0) throw new Error('不应播放');
+});
+
+check('手机端:视频与遮罩都收起(回到 body 默认渐变背景)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  if(e.els.bgVideo.style.visibility !== 'hidden') throw new Error('视频应隐藏');
+  if(e.els.bgVeil.style.visibility !== 'hidden') throw new Error('遮罩应隐藏');
+});
+
+// ---------- 2. 平板/桌面维持现状 ----------
+check('平板(1024x768):照常设 src + load + play(与改动前一致)', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  if(!/assets\/video\/bg-[123]\.mp4/.test(e.els.bgVideo.src))
+    throw new Error('应设置随机背景视频 src,实际 ' + e.els.bgVideo.src);
+  if(e.els.bgVideo._plays !== 1) throw new Error('应播放 1 次,实际 ' + e.els.bgVideo._plays);
+  if(e.els.bgVideo._loads < 1) throw new Error('应调用 load()');
+});
+
+check('平板:视频可见(与改动前一致)', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  if(e.els.bgVideo.style.visibility !== 'visible') throw new Error('视频应可见');
+});
+
+check('桌面(1400x900):照常设 src + play', () => {
+  const e = mkEnv({w:1400,h:900,dpr:1});
+  if(!e.els.bgVideo.src) throw new Error('应设置 src');
+  if(e.els.bgVideo._plays !== 1) throw new Error('应播放');
+});
+
+check('小平板(800x600,高度>460):不被手机横屏那条误命中,照常播放', () => {
+  const e = mkEnv({w:800,h:600,dpr:2});
+  if(!e.els.bgVideo.src) throw new Error('800x600 是平板,应照常播放');
+});
+
+// ---------- 3. 进房/回大厅往返 ----------
+check('平板:进房 pauseBgVideo 暂停并隐藏,回大厅 resumeBgVideo 恢复播放', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});
+  e.run('pauseBgVideo()');
+  if(e.els.bgVideo._pauses !== 1) throw new Error('应暂停');
+  if(e.els.bgVideo.style.visibility !== 'hidden') throw new Error('应隐藏');
+  if(e.els.bgVeil.style.visibility !== 'hidden') throw new Error('遮罩应隐藏');
+  const playsBefore = e.els.bgVideo._plays;
+  e.run('resumeBgVideo()');
+  if(e.els.bgVideo._plays !== playsBefore + 1) throw new Error('回大厅应重新播放');
+  if(e.els.bgVideo.style.visibility !== 'visible') throw new Error('视频应恢复可见');
+  if(e.els.bgVeil.style.visibility !== 'visible') throw new Error('遮罩应恢复可见');
+});
+
+check('手机:回大厅 resumeBgVideo 仍不播放、遮罩不显示', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('pauseBgVideo()');
+  e.run('resumeBgVideo()');
+  if(e.els.bgVideo._plays !== 0) throw new Error('手机端任何时候都不该播放,实际 ' + e.els.bgVideo._plays);
+  if(e.els.bgVideo.src) throw new Error('不该设 src');
+  if(e.els.bgVeil.style.visibility !== 'hidden')
+    throw new Error('没有视频时遮罩不该显示(否则只是把默认渐变再压暗一层)');
+});
+
+check('手机:反复往返多次都不播放、不下载', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  for(let i=0;i<5;i++){ e.run('pauseBgVideo()'); e.run('resumeBgVideo()'); }
+  if(e.els.bgVideo._plays !== 0) throw new Error('实际播放 ' + e.els.bgVideo._plays + ' 次');
+  if(e.els.bgVideo.src) throw new Error('不该设 src');
+});
+
+// ---------- 4. ★音轨解锁不被破坏 ----------
+check('★手机端首次交互仍解锁全部特效音轨(不播大厅视频≠特效变哑)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  ['bgVideo','deathFxVideo','lightningFxVideo','movieFxVideo'].forEach(id => {
+    if(e.els[id].muted !== true) throw new Error('前置:' + id + ' 初始应静音');
+  });
+  e.fireDoc('click');   // 模拟首次用户手势
+  ['deathFxVideo','lightningFxVideo','movieFxVideo'].forEach(id => {
+    if(e.els[id].muted !== false)
+      throw new Error(id + ' 应被解锁为有声——手机端不播大厅视频不该影响特效音轨');
+  });
+  if(e.get('fxAudioUnlocked') !== true) throw new Error('fxAudioUnlocked 应为 true');
+});
+
+check('手机端 applyFxAudio 在解锁后仍能给特效视频取消静音', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.fireDoc('click');
+  const v = { muted:true };
+  e.sandbox.__v = v;
+  e.run('applyFxAudio(__v)');
+  if(v.muted !== false) throw new Error('applyFxAudio 应取消静音');
+});
+
+// ---------- 5. 释放已下载的 src ----------
+check('已设过 src 后走收起分支:会 removeAttribute("src")+load() 释放', () => {
+  const e = mkEnv({w:1024,h:768,dpr:2});   // 先按平板加载,src 已设
+  if(!e.els.bgVideo.src) throw new Error('前置:平板应已设 src');
+  const removesBefore = e.els.bgVideo._removes;
+  e.sandbox.window.innerWidth = 844; e.sandbox.window.innerHeight = 390;  // 变成手机
+  e.run('pickRandomBgVideo()');
+  if(e.els.bgVideo._removes <= removesBefore) throw new Error('应释放已下载的 src');
+  if(e.els.bgVideo.src) throw new Error('src 应被清空');
+});
+
+check('从未设过 src 时不调 load()(避免无源警告)', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  // 加载即执行过一次 pickRandomBgVideo,走的是收起分支且 src 从未设过
+  if(e.els.bgVideo._loads !== 0)
+    throw new Error('没有 src 时不该调 load(),实际 ' + e.els.bgVideo._loads + ' 次');
+});
+
+// ---------- 6. pauseBgVideo 既有行为不变 ----------
+check('pauseBgVideo 源码未被本次改动触碰(仍是 pause+隐藏视频+隐藏遮罩)', () => {
+  const e = mkEnv();
+  const src = e.get('String(pauseBgVideo)');
+  if(!/pause\(\)/.test(src)) throw new Error('应仍调用 pause()');
+  if(!/visibility = 'hidden'/.test(src)) throw new Error('应仍隐藏视频');
+  if(!/bgVeil/.test(src)) throw new Error('应仍隐藏遮罩');
+  if(/shouldPlayLobbyVideo|isPhoneLayout/.test(src))
+    throw new Error('pauseBgVideo 不应引入本次新增的判定(它对所有设备行为一致)');
+});
+
+// ---------- 7. 破坏性验证 ----------
+check('破坏性验证:让 shouldPlayLobbyVideo 恒 true(=关掉本次限制),手机端断言确实会红', () => {
+  const e = mkEnv({w:844,h:390,dpr:3});
+  e.run('shouldPlayLobbyVideo = function(){ return true; };');
+  e.run('pickRandomBgVideo()');
+  if(!e.els.bgVideo.src)
+    throw new Error('关掉限制后手机端仍不设 src,说明手机端断言没有鉴别力');
+  if(e.els.bgVideo._plays === 0)
+    throw new Error('关掉限制后手机端应播放(= 改动前行为)');
+  console.log('       ↳ 关掉限制后手机端确实会加载 ' + e.els.bgVideo.src + ' 并播放(= 改动前行为)');
+});
+
+console.log('\n结果: ' + passed + ' 通过, ' + failed + ' 失败');
+if(failed > 0) process.exit(1);


### PR DESCRIPTION
perf(ui): CORE-144 手机端不播大厅背景视频(平板/桌面不变)

bg-1/2/3.mp4 各 5~6MB 且 loop 无限循环。大厅是"等朋友进房"的场景,可能停留好几
分钟,期间视频持续硬件解码;每次进大厅还会随机换一个重新加载,手机上额外吃 5~6MB
移动流量。纯装饰性动态背景在这里性价比最低。

范围只砍手机,平板/桌面维持现状——复用 CORE-141 已落地并测过的 isPhoneLayout()
(与 index.html 的 CSS 手机断点逐字同源),不新造第二套判定。

手机端效果:不设置 v.src(连下载都不发生——只 pause 不管 src 浏览器仍会拉完整个
文件)、不播放、隐藏视频与遮罩,回到 body 默认渐变背景,视觉落点与进房时
pauseBgVideo() 完全一致。新增 hideLobbyVideo() 在 src 已存在时一并释放
(removeAttribute+load,沿用 hideFxVideo 既有做法),覆盖跨断点残留;从未设过 src
时不调 load(),避免无源警告。

resumeBgVideo 手机端不显示遮罩:遮罩是用来压暗视频的,没有视频时只会把默认渐变
再无谓压暗一层。

刻意一个字节没碰:
- unmuteBgVideo/unlockFxAudio 音轨解锁(它还负责死亡/闪电/过场三条特效的音轨,
  手机端不播大厅视频≠可以跳过解锁,否则所有特效变哑),测试有专门断言
- pauseBgVideo(对所有设备行为一致),测试用源码断言钉住它没被塞进设备判定

新增 testclass/run_core144_lobby_video_test.js(17 条,含破坏性验证)
既有 run_fx_video_audio(3/3)、run_death_fx_detect(8/8)、run_core141(26/26)
全部零改动通过。全量 134/134。cache-bust: game-bg v12

Closes #197

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
