### PR TITLE
perf(ui): CORE-145 响应超时检测的 1s 定时器改为按需启停

### DIFF
--- a/bot-ai-bus.js
+++ b/bot-ai-bus.js
@@ -1007,18 +1007,63 @@ function refreshCountdownSpans(){
     spans[i].textContent = cd || '';
   }
 }
-// startAutoRespondTimer: 启动 1s 检测器。任意客户端都可启动(提交幂等);用标志位保证
-// 全局只启动一个实例。render() 每次渲染时调用它确保已启动(浏览器环境);vm 测试沙箱
-// 没有 setInterval/不需要启动,直接调 maybeAutoRespondTimeout 单步验证。
-let __autoRespondTimerStarted = false;
+// startAutoRespondTimer: 1s 检测器的**生命周期入口**。任意客户端都可启动(提交幂等)。
+// render() 每次渲染时调用它(浏览器环境);vm 测试沙箱没有 setInterval/不需要启动,
+// 直接调 maybeAutoRespondTimeout 单步验证。
+//
+// ============ CORE-145(issue #198):按需启停,不再永不停止 ============
+// 【改动前的问题】这个 setInterval 一旦启动就**永不停止**(全文没有任何 clearInterval):
+// 游戏结束后、回到大厅后仍然每秒醒来。单次 tick 的实际开销确实很低——无 pending 时
+// maybeAutoRespondTimeout 首行 `if(!g.pending || typeof g.pending.askedAt!=='number')`
+// 直接返回、refreshCountdownSpans 拿到空 NodeList——但 1Hz 常驻唤醒会妨碍 JS 引擎进入
+// 深度空闲状态,在移动端有一定影响(这是耗电分析四项里最小的一项,比 CORE-141 的全屏
+// Canvas 每帧重绘小一个数量级以上;单独做收益有限,价值在于顺手清掉一个资源泄漏式写法)。
+//
+// 【为什么可以安全地停】超时托管本身(RESPONSE_TIMEOUT_MS=30000 的自动保守提交)是防挂机
+// 卡死的关键机制,停掉的前提必须是"一旦出现询问型 pending 就能及时重新启动"。这一点由
+// 既有结构天然保证:render() 由 gameRef.on('value') 驱动,**任何** pending 的创建都来自
+// 一次 tx 状态变更 → 必然触发本端 render → 必然走到这里。而 render 里 `currentG = g`
+// 就在调用本函数的前一行,所以这里读到的一定是最新快照,不会拿旧状态误判。
+//
+// 【单实例不变量】改动前靠 __autoRespondTimerStarted 这个**单向**布尔保证"只启动一次";
+// 现在可停可启,单向标志不够用了,改成持有 timer id(null = 未运行)。所有启停都必须经过
+// 这里和 stopAutoRespondTimer,不要在别处直接 setInterval/clearInterval——测试有断言钉住
+// "反复调用不会起多个实例"。
+let __autoRespondTimerId = null;
+// autoRespondTimerNeeded: 当前是否需要 1s 检测器。口径与 maybeAutoRespondTimeout /
+// renderResponseCountdown 的前置判断**逐字一致**(都要求 pending 存在且 askedAt 是数字
+// = 已被 setResponseAskedAt 打过戳),避免出现"检测器停了但那两个函数其实还有事要做"。
+function autoRespondTimerNeeded(){
+  const g = (typeof currentG!=='undefined') ? currentG : null;
+  return !!(g && g.pending && typeof g.pending.askedAt === 'number');
+}
+function stopAutoRespondTimer(){
+  if(__autoRespondTimerId!==null && typeof clearInterval!=='undefined'){
+    clearInterval(__autoRespondTimerId);
+  }
+  __autoRespondTimerId = null;
+  // 停机时刷一次:把可能残留的"⏱ Ns 后自动…"文案清掉(询问已结束,倒计时不该定格在画面上)。
+  // refreshCountdownSpans 在没有倒计时可显示时写的就是空串,这里复用同一条路径,不另写清理。
+  refreshCountdownSpans();
+}
 function startAutoRespondTimer(){
-  if(__autoRespondTimerStarted) return;
   if(typeof setInterval==='undefined') return;
-  __autoRespondTimerStarted = true;
-  setInterval(function(){
-    if(typeof currentG!=='undefined' && currentG){
-      maybeAutoRespondTimeout(currentG);
-      refreshCountdownSpans();
-    }
-  }, 1000);
+  const need = autoRespondTimerNeeded();
+  if(need){
+    if(__autoRespondTimerId!==null) return; // 已在运行:幂等,不重复起
+    __autoRespondTimerId = setInterval(function(){
+      if(typeof currentG!=='undefined' && currentG){
+        maybeAutoRespondTimeout(currentG);
+        refreshCountdownSpans();
+      }
+      // 自我停机兜底:正常情况下询问结束会触发 render → 走上面的 !need 分支停掉;
+      // 这一条是防"本端因为某种原因没再收到 render"时定时器永远转下去(回到改动前的
+      // 行为)。注意提交是异步的(tx 往返),刚 maybeAutoRespondTimeout 提交完这一拍
+      // currentG 还是旧快照、仍然 need,会在随后某一拍或 render 时才真正停——这是对的,
+      // 不能因为"刚提交过"就提前停掉,否则提交失败时就没人继续兜底了。
+      if(!autoRespondTimerNeeded()) stopAutoRespondTimer();
+    }, 1000);
+    return;
+  }
+  if(__autoRespondTimerId!==null) stopAutoRespondTimer();
 }

--- a/docs/progress-log-11.md
+++ b/docs/progress-log-11.md
@@ -225,3 +225,18 @@
 
   **判断轴**：只换素材 + 给 `<img>` 加一个属性，不触碰机器人决策链与 `pending` 流转，轴 A/B 均未命中；实际仍跑了全量 **135/135** 通过。**cache-bust**：`render.js` v435→436、`render-table.js` v395→396、`render-hand.js` v394→395、`render-controls.js` v421→422。**未做真机实测**：解码成本正比于像素数，-61%/-64% 的降幅是确定的，但具体省多少电需真机确认。
 
+
+- **CORE-145(issue #198):响应超时检测的 1s 定时器改为按需启停**：手机/平板耗电分析四项里**影响最小的一项**，也是改动最小的一项。**问题**：`startAutoRespondTimer()` 启动的 `setInterval` **一旦启动就永不停止**（全文没有任何 `clearInterval`），游戏结束后、回到大厅后仍然每秒醒来。**如实说明影响量级**：单次 tick 的实际开销很低——无 pending 时 `maybeAutoRespondTimeout` 首行判断直接返回、`refreshCountdownSpans` 拿到空 NodeList；真正的代价是 1Hz 常驻唤醒妨碍 JS 引擎进入深度空闲，**比 CORE-141 的全屏 Canvas 每帧重绘小一个数量级以上**。单独做收益有限，价值在于顺手清掉一个资源泄漏式写法。
+
+  **为什么可以安全地停（这是本次唯一需要论证的点）**：超时托管（`RESPONSE_TIMEOUT_MS=30000` 的自动保守提交）是防挂机卡死的关键机制，停掉的前提必须是「一旦出现询问型 pending 就能及时重新启动」。这一点由**既有结构天然保证**：`render()` 由 `gameRef.on('value')` 驱动，**任何** pending 的创建都来自一次 tx 状态变更 → 必然触发本端 render → 必然走到 `startAutoRespondTimer()`；而 render 里 `currentG = g` 就在调用它的**前一行**，所以读到的一定是最新快照，不会拿旧状态误判。这条顺序依赖已在 `render.js` 的注释里写明（「**必须在 `currentG = g` 之后调用**」）。
+
+  **实现**：`startAutoRespondTimer()` 从「只负责启动」升级成**生命周期入口**——`autoRespondTimerNeeded()` 判定当前该不该跑（口径与 `maybeAutoRespondTimeout`/`renderResponseCountdown` 的前置判断**逐字一致**：`pending` 存在且 `askedAt` 是数字 = 已被 `setResponseAskedAt` 打过戳，避免出现「检测器停了但那两个函数其实还有事要做」），需要就起、不需要就 `stopAutoRespondTimer()`。**单实例不变量的维护方式变了**：改动前靠 `__autoRespondTimerStarted` 这个**单向**布尔保证「只启动一次」，现在可停可启、单向标志不够用，改成持有 `__autoRespondTimerId`（`null` = 未运行）；所有启停都必须经过这两个函数，测试有断言钉住「反复调用不会起多个实例」和「多轮启停后不泄漏」。停机时顺带调一次 `refreshCountdownSpans()` 清掉可能残留的「⏱ Ns 后自动…」文案（复用同一条路径，不另写清理逻辑）。
+
+  **tick 里的自我停机兜底与一个刻意的「不停」**：tick 末尾加了 `if(!autoRespondTimerNeeded()) stopAutoRespondTimer()`，防「本端因为某种原因没再收到 render」时定时器永远转下去（回到改动前的行为）。但**刚提交完保守动作的那一拍刻意不停**——tx 是异步的，`maybeAutoRespondTimeout` 提交后 `currentG` 还是旧快照、仍然 `need`，要等 tx 回执触发 render 或后续某拍才真正停；**如果因为「刚提交过」就提前停掉，提交失败时就没人继续兜底了**。测试里对这条有专门断言。
+
+  **测试**：新增 `testclass/run_core145_timer_lifecycle_test.js`（14 条），覆盖无 pending/`currentG=null` 不启动、有询问型 pending 启动且周期 1000ms、pending 消失即停并清理文案、★单实例不变量（连调 20 次仍只 1 个）、★停掉后再出现 pending 能重新启动（超时托管不被破坏）、10 轮启停循环后无泄漏、`askedAt` 未打戳不算、`autoRespondTimerNeeded` 四种输入的口径、tick 里仍调 `maybeAutoRespondTimeout`+`refreshCountdownSpans`、自我停机兜底、★提交后不立刻自停，外加**破坏性验证**（让 `autoRespondTimerNeeded` 恒 true = 回到永不停止，确认停机断言确实会红）。
+
+  **既有测试核对**：`run_ai_timeout_test.js`（23 条）**零改动通过**——它是直接单步调 `maybeAutoRespondTimeout` 验证保守动作的，文件头注释就写着「vm 测试沙箱没有 `setInterval`/不需要启动，直接调 `maybeAutoRespondTimeout` 单步验证」，因此完全不依赖定时器本身，本次改动结构上碰不到它。全项目 `grep` 确认没有任何测试引用 `__autoRespondTimerStarted`。
+
+  **判断轴 B 命中**（触碰询问型 pending 的超时托管机制）→ 按规则 29 跑了全量 **136/136** + **soak 两轮**（60局7人 + 120局7人）：均为「正常结束 全部 / 卡死0 / 步数超限0 / 异常崩溃0 / 阵营违规0」。**cache-bust**：`bot-ai-bus.js` v410→412、`render.js` v436→437。
+

--- a/index.html
+++ b/index.html
@@ -2526,10 +2526,10 @@
 <script src="weapons.js?v=399"></script>
 <script src="skills.js?v=409"></script>
 <script src="skills/late-generals.js?v=404"></script>
-<script src="bot-ai-bus.js?v=411"></script>
+<script src="bot-ai-bus.js?v=412"></script>
 <script src="bot.js?v=428"></script>
 <script src="ai-bot.js?v=411"></script>
-<script src="render.js?v=436"></script>
+<script src="render.js?v=437"></script>
 <script src="render-table.js?v=396"></script>
 <script src="render-discard.js?v=395"></script>
 <script src="render-hand.js?v=395"></script>

--- a/render.js
+++ b/render.js
@@ -1356,8 +1356,10 @@ function checkDeaths(g){
 // ---------- render ----------
 function render(g){
   currentG = g; // 供确认弹窗的取消回调异步刷新界面用(回调触发时早已不在 render 的调用栈里)
-  // A1 响应超时托管:确保 1s 检测器已启动(任意客户端;提交幂等,谁先到谁生效)。
-  // startAutoRespondTimer 内部有全局标志位,反复 render 只会启动一次。
+  // A1 响应超时托管:同步 1s 检测器的启停(任意客户端;提交幂等,谁先到谁生效)。
+  // CORE-145 起它是"按需启停"的生命周期入口而不只是"启动":有询问型 pending 才运行,
+  // 没有就停掉。内部持有 timer id 保证幂等,反复 render 不会起多个实例。
+  // **必须在 currentG = g 之后调用**——它读 currentG 判断当前该不该运行。
   if(typeof startAutoRespondTimer==='function') startAutoRespondTimer();
   if(!g){
     // room was deleted by someone (or doesn't exist) while we're in-game -> return to lobby

--- a/testclass/run_core145_timer_lifecycle_test.js
+++ b/testclass/run_core145_timer_lifecycle_test.js
@@ -1,0 +1,217 @@
+/**
+ * CORE-145(issue #198): 响应超时检测的 1s 定时器改为按需启停。
+ *
+ * 【最重要的不变量】超时托管本身不能被破坏——一旦出现询问型 pending 就必须能及时
+ * 重新启动,否则挂机会永久卡死。测试里对"启动时机"和"单实例"两条都做了正面+反面覆盖。
+ *
+ * 覆盖:
+ *  1. 无 pending → 不启动(改动前会启动并永远转下去)
+ *  2. 有询问型 pending → 启动
+ *  3. pending 消失 → 停掉,并清理残留倒计时文案
+ *  4. 单实例不变量:反复调用不会起多个 interval
+ *  5. 停掉后再出现 pending → 能重新启动(超时托管不被破坏)
+ *  6. askedAt 未打戳的 pending 不算(与 maybeAutoRespondTimeout 口径一致)
+ *  7. tick 里仍会调 maybeAutoRespondTimeout + refreshCountdownSpans
+ *  8. 自我停机兜底:currentG 失去 pending 后下一拍自停
+ *  9. 提交后不立刻自停(异步 tx 未回,仍需继续兜底)
+ * 10. 破坏性验证:断言有鉴别力
+ */
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+let passed = 0, failed = 0;
+function check(name, fn){
+  try { fn(); console.log('  PASS', name); passed++; }
+  catch(e){ console.log('  FAIL', name, '-', (e && e.message) || e); failed++; }
+}
+
+function mkEnv(){
+  const timers = { created: [], cleared: [], nextId: 1, active: new Map() };
+  const spans = [];
+  const context = {
+    Math, console, Number, String, Array, Object, JSON, Date,
+    setInterval(fn, ms){
+      const id = timers.nextId++;
+      timers.created.push({ id, ms, fn });
+      timers.active.set(id, fn);
+      return id;
+    },
+    clearInterval(id){ timers.cleared.push(id); timers.active.delete(id); },
+    setTimeout(){ return 0; }, clearTimeout(){},
+    document: {
+      getElementById(){ return null; },
+      querySelectorAll(sel){ return sel === '.resp-countdown' ? spans : []; },
+      addEventListener(){}, removeEventListener(){},
+      body:{}, createElement(){ return { style:{}, classList:{add(){},remove(){}}, appendChild(){} }; },
+      querySelector(){ return null; }
+    },
+    window: { addEventListener(){}, removeEventListener(){}, matchMedia(){ return { matches:false }; },
+      requestAnimationFrame(){ return 1; }, cancelAnimationFrame(){}, innerWidth:1400, innerHeight:900 },
+    // 只加载 bot-ai-bus.js,不拉整条依赖链;它引用的跨文件函数按需 stub
+    currentG: null,
+    RESPONSE_TIMEOUT_MS: 30000
+  };
+  context.window.document = context.document;
+  context.global = context;
+  const sandbox = vm.createContext(context);
+  // bot-ai-bus.js 里 maybeAutoRespondTimeout 会调 autoRespondAction/pendingResponderSeat 等
+  // (定义在 stage-table/game.js),本用例只关心"定时器有没有起/停/tick 里调了谁",
+  // 因此把这两个函数换成 spy——它们的真实行为由 run_ai_timeout_test.js 单独覆盖。
+  vm.runInContext(fs.readFileSync(path.join(ROOT,'data.js'),'utf8'), sandbox, {filename:'data.js'});
+  vm.runInContext(fs.readFileSync(path.join(ROOT,'stages/stage-table.js'),'utf8'), sandbox, {filename:'stage-table.js'});
+  vm.runInContext(fs.readFileSync(path.join(ROOT,'bot-ai-bus.js'),'utf8'), sandbox, {filename:'bot-ai-bus.js'});
+  vm.runInContext(`
+    window.__maybeCalls = 0; window.__refreshCalls = 0;
+    maybeAutoRespondTimeout = function(){ window.__maybeCalls++; return false; };
+    refreshCountdownSpans = function(){ window.__refreshCalls++; };
+  `, sandbox);
+  return {
+    sandbox, timers, spans,
+    get: e => vm.runInContext(e, sandbox),
+    run: e => vm.runInContext(e, sandbox),
+    setG(g){ vm.runInContext('currentG = ' + JSON.stringify(g), sandbox); },
+    tick(){ timers.active.forEach(fn => fn()); }
+  };
+}
+const asking = (extra) => Object.assign({ pending:{ type:'shan', askedAt: Date.now() }, phase:'respond', players:[] }, extra||{});
+
+console.log('\n' + '='.repeat(60));
+console.log('  CORE-145:1s 超时检测器按需启停');
+console.log('='.repeat(60) + '\n');
+
+check('无 pending → 不启动定时器(改动前会启动并永远转下去)', () => {
+  const e = mkEnv();
+  e.setG({ phase:'play', pending:null, players:[] });
+  e.run('startAutoRespondTimer()');
+  if(e.timers.created.length !== 0) throw new Error('不该起定时器,实际起了 ' + e.timers.created.length + ' 个');
+  if(e.get('__autoRespondTimerId') !== null) throw new Error('timer id 应为 null');
+});
+
+check('currentG 为 null(还没进对局)→ 不启动', () => {
+  const e = mkEnv();
+  e.run('startAutoRespondTimer()');
+  if(e.timers.created.length !== 0) throw new Error('不该起定时器');
+});
+
+check('出现询问型 pending → 启动,周期 1000ms', () => {
+  const e = mkEnv();
+  e.setG(asking());
+  e.run('startAutoRespondTimer()');
+  if(e.timers.created.length !== 1) throw new Error('应起 1 个定时器,实际 ' + e.timers.created.length);
+  if(e.timers.created[0].ms !== 1000) throw new Error('周期应为 1000ms,实际 ' + e.timers.created[0].ms);
+});
+
+check('pending 消失 → 停掉定时器', () => {
+  const e = mkEnv();
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  const id = e.timers.created[0].id;
+  e.setG({ phase:'play', pending:null, players:[] });
+  e.run('startAutoRespondTimer()');
+  if(e.timers.cleared.indexOf(id) < 0) throw new Error('应 clearInterval 掉它');
+  if(e.get('__autoRespondTimerId') !== null) throw new Error('timer id 应回到 null');
+});
+
+check('停机时清理残留倒计时文案(调 refreshCountdownSpans)', () => {
+  const e = mkEnv();
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  const before = e.get('window.__refreshCalls');
+  e.setG({ phase:'play', pending:null, players:[] });
+  e.run('startAutoRespondTimer()');
+  if(e.get('window.__refreshCalls') <= before)
+    throw new Error('停机时应刷一次倒计时文案,避免"⏱ Ns 后自动…"定格在画面上');
+});
+
+check('★单实例不变量:反复调用不会起多个 interval', () => {
+  const e = mkEnv();
+  e.setG(asking());
+  for(let i=0;i<20;i++) e.run('startAutoRespondTimer()');
+  if(e.timers.created.length !== 1)
+    throw new Error('反复调用应只有 1 个实例,实际 ' + e.timers.created.length + ' 个');
+});
+
+check('★停掉后再出现 pending → 能重新启动(超时托管不被破坏)', () => {
+  const e = mkEnv();
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  e.setG({ phase:'play', pending:null, players:[] }); e.run('startAutoRespondTimer()');
+  if(e.get('__autoRespondTimerId') !== null) throw new Error('前置:应已停');
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  if(e.get('__autoRespondTimerId') === null) throw new Error('再次出现询问型 pending 时必须能重新启动');
+  if(e.timers.created.length !== 2) throw new Error('应共起过 2 次,实际 ' + e.timers.created.length);
+});
+
+check('多轮启停循环后仍只有 1 个活跃实例(不泄漏)', () => {
+  const e = mkEnv();
+  for(let i=0;i<10;i++){
+    e.setG(asking()); e.run('startAutoRespondTimer()');
+    e.setG({ phase:'play', pending:null, players:[] }); e.run('startAutoRespondTimer()');
+  }
+  if(e.timers.active.size !== 0) throw new Error('最终应无活跃定时器,实际 ' + e.timers.active.size);
+  if(e.timers.created.length !== e.timers.cleared.length)
+    throw new Error('起 ' + e.timers.created.length + ' 次但只清了 ' + e.timers.cleared.length + ' 次(泄漏)');
+});
+
+check('askedAt 未打戳的 pending 不算(与 maybeAutoRespondTimeout 口径一致)', () => {
+  const e = mkEnv();
+  e.setG({ phase:'respond', pending:{ type:'shan' }, players:[] });   // 没有 askedAt
+  e.run('startAutoRespondTimer()');
+  if(e.timers.created.length !== 0)
+    throw new Error('askedAt 不是数字时 maybeAutoRespondTimeout 会直接返回,不该起定时器');
+});
+
+check('autoRespondTimerNeeded 的口径:pending 存在且 askedAt 是数字', () => {
+  const e = mkEnv();
+  e.setG(null);
+  if(e.get('autoRespondTimerNeeded()') !== false) throw new Error('currentG=null 应为 false');
+  e.setG({ pending:null });
+  if(e.get('autoRespondTimerNeeded()') !== false) throw new Error('无 pending 应为 false');
+  e.setG({ pending:{ type:'shan' } });
+  if(e.get('autoRespondTimerNeeded()') !== false) throw new Error('无 askedAt 应为 false');
+  e.setG({ pending:{ type:'shan', askedAt: 123 } });
+  if(e.get('autoRespondTimerNeeded()') !== true) throw new Error('有戳应为 true');
+});
+
+check('tick 里仍会调 maybeAutoRespondTimeout + refreshCountdownSpans(既有行为)', () => {
+  const e = mkEnv();
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  const m0 = e.get('window.__maybeCalls'), r0 = e.get('window.__refreshCalls');
+  e.tick();
+  if(e.get('window.__maybeCalls') !== m0 + 1) throw new Error('每拍应调一次 maybeAutoRespondTimeout');
+  if(e.get('window.__refreshCalls') <= r0) throw new Error('每拍应刷一次倒计时');
+});
+
+check('自我停机兜底:currentG 失去 pending 后下一拍自停(不依赖 render)', () => {
+  const e = mkEnv();
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  const id = e.timers.created[0].id;
+  e.setG({ phase:'play', pending:null, players:[] });   // 只改状态,不调 startAutoRespondTimer
+  e.tick();
+  if(e.timers.cleared.indexOf(id) < 0)
+    throw new Error('tick 里应自我停机(防本端收不到 render 时永远转下去)');
+});
+
+check('★提交后不立刻自停:pending 仍在时继续兜底(tx 是异步的)', () => {
+  const e = mkEnv();
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  const id = e.timers.created[0].id;
+  e.tick();  // 这一拍 maybeAutoRespondTimeout 提交了保守动作,但 currentG 还是旧快照
+  if(e.timers.cleared.indexOf(id) >= 0)
+    throw new Error('刚提交过就停掉的话,提交失败时就没人继续兜底了');
+  if(e.timers.active.size !== 1) throw new Error('应仍在运行');
+});
+
+check('破坏性验证:让 autoRespondTimerNeeded 恒 true(=回到永不停止),停机断言确实会红', () => {
+  const e = mkEnv();
+  e.run('autoRespondTimerNeeded = function(){ return true; };');
+  e.setG(asking()); e.run('startAutoRespondTimer()');
+  const id = e.timers.created[0].id;
+  e.setG({ phase:'play', pending:null, players:[] });
+  e.run('startAutoRespondTimer()');
+  if(e.timers.cleared.indexOf(id) >= 0)
+    throw new Error('恒 true 时不该停,说明停机断言没有鉴别力');
+  console.log('       ↳ 恒 true 时定时器确实永不停止(= 改动前行为),停机断言有鉴别力');
+});
+
+console.log('\n结果: ' + passed + ' 通过, ' + failed + ' 失败');
+if(failed > 0) process.exit(1);


### PR DESCRIPTION
perf(ui): CORE-145 响应超时检测的 1s 定时器改为按需启停

startAutoRespondTimer 的 setInterval 一旦启动就永不停止(全文没有任何 clearInterval),
游戏结束后、回到大厅后仍每秒醒来。单次 tick 开销很低(无 pending 时两个函数都立刻
返回),代价是 1Hz 常驻唤醒妨碍 JS 引擎进入深度空闲——比 CORE-141 的全屏 Canvas
每帧重绘小一个数量级以上,单独收益有限,价值在于清掉一个资源泄漏式写法。

为什么可以安全地停:超时托管是防挂机卡死的关键机制,停的前提是"一旦出现询问型
pending 就能及时重启"。这由既有结构天然保证——render() 由 gameRef.on('value') 驱动,
任何 pending 的创建都来自 tx 状态变更 → 必然触发本端 render → 必然走到这里;而
render 里 currentG = g 就在调用它的前一行,读到的一定是最新快照。

实现:startAutoRespondTimer 升级为生命周期入口,autoRespondTimerNeeded() 判定该不该跑
(口径与 maybeAutoRespondTimeout/renderResponseCountdown 的前置判断逐字一致:pending
存在且 askedAt 是数字)。单实例不变量的维护方式随之改变:原来的单向布尔
__autoRespondTimerStarted 不够用,改成持有 timer id。停机时顺带清一次残留倒计时文案。

tick 末尾加自我停机兜底(防本端收不到 render 时永远转下去);但刚提交完保守动作的
那一拍刻意不停——tx 异步,currentG 还是旧快照,若因"刚提交过"提前停掉,提交失败时
就没人继续兜底了。测试对这条有专门断言。

新增 testclass/run_core145_timer_lifecycle_test.js(14 条,含破坏性验证)
既有 run_ai_timeout_test.js(23/23) 零改动通过——它直接单步调 maybeAutoRespondTimeout,
不依赖定时器本身;全项目 grep 确认无测试引用 __autoRespondTimerStarted。

判断轴 B 命中(超时托管机制)→ 全量 136/136 + soak 两轮(60局7人 + 120局7人)
均为 卡死0/步数超限0/异常崩溃0/阵营违规0。

cache-bust: bot-ai-bus v412, render v437

Closes #198

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
